### PR TITLE
supported camps API

### DIFF
--- a/app/Http/Controllers/SupportController.php
+++ b/app/Http/Controllers/SupportController.php
@@ -33,8 +33,6 @@ class SupportController extends Controller
         try {
             
             $response = DB::select("CALL user_support('direct', $userId)");
-            
-        echo "<pre>"; print_r($response); exit;
             $directSupports = [];
             foreach($response as $k => $support){
 
@@ -51,7 +49,7 @@ class SupportController extends Controller
                     $directSupports[$support->topic_num] = array(
                         'topic_num' => $support->topic_num,
                         'title' => $support->title,
-                        'title_link' => Topic::TopicLink($support->topic_num,1,$support->title),
+                        'title_link' => Topic::topicLink($support->topic_num,1,$support->title),
                         'camps' => array(
                                 [
                                     'camp_num' => $support->camp_num,
@@ -111,7 +109,7 @@ class SupportController extends Controller
                     $directSupports[$support->topic_num] = array(
                         'topic_num' => $support->topic_num,
                         'title' => $support->title,
-                        'title_link' => Topic::TopicLink($support->topic_num,1,$support->title),
+                        'title_link' => Topic::topicLink($support->topic_num,1,$support->title),
                         'camps' => array(
                                 [
                                     'camp_num' => $support->camp_num,

--- a/app/Http/Controllers/SupportController.php
+++ b/app/Http/Controllers/SupportController.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\AddNickNameRequest;
+use App\Http\Requests\UpdateNickNameRequest;
+use App\Models\Nickname;
+use Illuminate\Http\Request;
+use App\Models\Support;
+use App\Models\Camp;
+use App\Models\Topic;
+use DB;
+
+
+class SupportController extends Controller
+{
+    
+
+    /**
+     * @OA\Get(path="/get-direct-supported-camps",
+     *   tags={"support"},
+     *   summary="Get list of all the direct supported camps",
+     *   description="Get list of all the direct supported camps",
+     *   operationId="directSupport",
+     *   @OA\Response(response=200, description="Success"),
+     *   @OA\Response(response=400, description="Something went wrong")
+     * )
+     */
+    public function getDirectSupportedCamps(Request $request)
+    {
+        $user = $request->user();
+        $userId = $user->id;
+        try {
+            
+            $response = DB::select("CALL user_support('direct', $userId)");
+            
+            $directSupports = [];
+            foreach($response as $k => $support){
+
+                if(isset($directSupports[$support->topic_num])){
+                    $tempCamp = [
+                        'camp_num' => $support->camp_num,
+                        'camp_name' => $support->camp_name,
+                        'support_order'=> $support->support_order,
+                        'camp_link' => Camp::campLink($support->topic_num,$support->camp_num,$support->title,$support->camp_name),
+                    ];
+                    array_push($directSupports[$support->topic_num]['camps'],$tempCamp);
+
+                }else{
+                    $directSupports[$support->topic_num] = array(
+                        'topic_num' => $support->topic_num,
+                        'title' => $support->title,
+                        'title_link' => Topic::TopicLink($support->topic_num,1,$support->title),
+                        'camps' => array(
+                                [
+                                    'camp_num' => $support->camp_num,
+                                    'camp_name' => $support->camp_name,
+                                    'support_order' => $support->support_order,
+                                    'camp_link' =>  Camp::campLink($support->topic_num,$support->camp_num,$support->title,$support->camp_name),
+
+                                ]
+                        ),
+                    );
+                }
+            }
+            return $this->resProvider->apiJsonResponse(200, trans('message.success.success'), $directSupports, '');
+
+        } catch (\Throwable $e) {
+            return $this->resProvider->apiJsonResponse(400, trans('message.error.exception'), '', $e->getMessage());
+        }
+
+    }
+
+
+    /**
+     * @OA\Get(path="/get-delegate-supported-camps",
+     *   tags={"support"},
+     *   summary="Get list of all the direct supported camps",
+     *   description="Get list of all the direct supported camps",
+     *   operationId="delegateSupport",
+     *   @OA\Response(response=200, description="Success"),
+     *   @OA\Response(response=400, description="Something went wrong")
+     * )
+     */
+    public function getDelegatedSupportedCamps(Request $request)
+    {
+        $user = $request->user();
+        $userId = $user->id;
+        try {
+            
+            $response = DB::select("CALL user_support('delegate', $userId)");
+            $directSupports = [];
+            foreach($response as $k => $support){
+
+                if(isset($directSupports[$support->topic_num])){
+                    $tempCamp = [
+                        'camp_num' => $support->camp_num,
+                        'camp_name' => $support->camp_name,
+                        'support_order'=> $support->support_order,
+                        'camp_link' => Camp::campLink($support->topic_num,$support->camp_num,$support->title,$support->camp_name),
+                        'my_nick_name' => $support->my_nick_name,
+                        'my_nick_name_link' => Nickname::getNickNameLink($userId, $support->namespace_id, $support->topic_num, $support->camp_num),
+                        'delegated_to_nick_name' => $support->delegated_to_nick_name,
+                        'delegated_to_nick_name_link' => Nickname::getNickNameLink($support->delegate_user_id, $support->namespace_id, $support->topic_num, $support->camp_num),
+                        'support_added' => date('Y-m-d',$support->start)
+                    ];
+                    array_push($directSupports[$support->topic_num]['camps'],$tempCamp);
+
+                }else{
+                    $directSupports[$support->topic_num] = array(
+                        'topic_num' => $support->topic_num,
+                        'title' => $support->title,
+                        'title_link' => Topic::TopicLink($support->topic_num,1,$support->title),
+                        'camps' => array(
+                                [
+                                    'camp_num' => $support->camp_num,
+                                    'camp_name' => $support->camp_name,
+                                    'support_order' => $support->support_order,
+                                    'camp_link' =>  Camp::campLink($support->topic_num,$support->camp_num,$support->title,$support->camp_name),
+                                    'my_nick_name' => $support->my_nick_name,
+                                    'my_nick_name_link' => Nickname::getNickNameLink($userId, $support->namespace_id, $support->topic_num, $support->camp_num),
+                                    'delegated_to_nick_name' => $support->delegated_to_nick_name,
+                                    'delegated_to_nick_name_link' => Nickname::getNickNameLink($support->delegate_user_id, $support->namespace_id, $support->topic_num,  $support->camp_num),
+                                    'support_added' => date('Y-m-d',$support->start)
+
+                                ]
+                        ),
+                    );
+                }
+            }
+            return $this->resProvider->apiJsonResponse(200, trans('message.success.success'), $directSupports, '');
+
+        } catch (\Throwable $e) {
+            return $this->resProvider->apiJsonResponse(400, trans('message.error.exception'), '', $e->getMessage());
+        }
+
+    }
+}

--- a/app/Http/Controllers/SupportController.php
+++ b/app/Http/Controllers/SupportController.php
@@ -34,6 +34,7 @@ class SupportController extends Controller
             
             $response = DB::select("CALL user_support('direct', $userId)");
             
+        echo "<pre>"; print_r($response); exit;
             $directSupports = [];
             foreach($response as $k => $support){
 

--- a/app/Models/Camp.php
+++ b/app/Models/Camp.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use App\Facades\Util;
+
+
+class Camp extends Model {
+
+    protected $table = 'camp';
+    public $timestamps = false;
+
+
+    public static function campLink($topicNum,$campNum,$title,$campName){
+        $title = preg_replace('/[^A-Za-z0-9\-]/', '-', $title);
+        $campName = preg_replace('/[^A-Za-z0-9\-]/', '-', $campName);
+        $topicId = $topicNum . "-" . $title;
+        $campId = $campNum . "-" .$campName;
+        $queryString = (app('request')->getQueryString()) ? '?'.app('request')->getQueryString() : "";
+        return $link = url('topic/' . $topicId . '/' . $campId .'#statement');
+    }
+
+
+
+    
+}

--- a/app/Models/Nickname.php
+++ b/app/Models/Nickname.php
@@ -56,5 +56,17 @@ class Nickname extends Model {
         return $nicknames;
     }
 
+    public static function getNicknamesIdsByUserId($userID)
+    {
+        $ownerCode = Util::canon_encode($userID);
+
+        $nicknames = self::where('owner_code', $ownerCode)->pluck('id')->toArray();
+        return $nicknames;
+    }
+
+    public static function getNickNameLink($userId, $namespaceId, $topicNum='', $campNum=''){
+        return url('user/supports/'.$userId .'?topicnum='.$topicNum . '&campnum='.$campNum .'&namespace='.$namespaceId);
+    }
+
     
 }

--- a/app/Models/Support.php
+++ b/app/Models/Support.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use App\Facades\Util;
+
+
+class Support extends Model {
+
+    protected $table = 'support';
+    public $timestamps = false;
+
+/**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'nick_name_id','delegate_nick_name_id','camp_num','topic_num','start','end','flags'
+    ];
+
+
+    public function getStartAttribute($value){
+        return date("Y-m-d", strtotime($value));
+    }
+
+    
+}

--- a/app/Models/Topic.php
+++ b/app/Models/Topic.php
@@ -11,7 +11,7 @@ class Topic extends Model {
     protected $table = 'topic';
     public $timestamps = false;
 
-    public static function TopicLink($topicNum, $campNum = 1 , $title, $campName = 'Aggreement'){
+    public static function topicLink($topicNum, $campNum = 1 , $title, $campName = 'Aggreement'){
         $title = preg_replace('/[^A-Za-z0-9\-]/', '-', $title);
         $campName = preg_replace('/[^A-Za-z0-9\-]/', '-', $campName);
         $topicId = $topicNum . "-" . $title;

--- a/app/Models/Topic.php
+++ b/app/Models/Topic.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use App\Facades\Util;
+
+
+class Topic extends Model {
+
+    protected $table = 'topic';
+    public $timestamps = false;
+
+    public static function TopicLink($topicNum, $campNum = 1 , $title, $campName = 'Aggreement'){
+        $title = preg_replace('/[^A-Za-z0-9\-]/', '-', $title);
+        $campName = preg_replace('/[^A-Za-z0-9\-]/', '-', $campName);
+        $topicId = $topicNum . "-" . $title;
+        $campId = $campNum . "-" .$campName;
+        $queryString = (app('request')->getQueryString()) ? '?'.app('request')->getQueryString() : "";
+        return $link = url('topic/' . $topicId . '/' . $campId);
+    }
+
+    
+}

--- a/database/migrations/2022_03_08_104739_create_topic_table.php
+++ b/database/migrations/2022_03_08_104739_create_topic_table.php
@@ -27,8 +27,8 @@ class CreateTopicTable extends Migration
                 $table->integer('objector_nick_id')->nullable();
                 $table->integer('object_time')->nullable();
                 $table->longText('object_reason')->nullable();
-                $table->integer('proposed');
-                $table->bigInteger('replacement');
+                $table->integer('proposed')->nullable();
+                $table->bigInteger('replacement')->nullable();
                 $table->integer('namespace_id');
                 $table->integer('grace_period')->default(0);
             });

--- a/database/migrations/2022_03_08_122027_create_camp_table.php
+++ b/database/migrations/2022_03_08_122027_create_camp_table.php
@@ -17,7 +17,7 @@ class CreateCampTable extends Migration
             Schema::create('camp', function (Blueprint $table) {
                 $table->id();
                 $table->integer('topic_num');
-                $table->integer('parent_camp_num');
+                $table->integer('parent_camp_num')->nullable();
                 $table->integer('camp_num');
                 $table->string('title',555);
                 $table->string('camp_name',555);
@@ -30,10 +30,10 @@ class CreateCampTable extends Migration
                 $table->integer('objector_nick_id')->nullable();
                 $table->integer('object_time')->nullable();
                 $table->longText('object_reason')->nullable();
-                $table->integer('proposed');
-                $table->bigInteger('replacement');
-                $table->mediumText('camp_about_url');
-                $table->integer('camp_about_nick_id');
+                $table->integer('proposed')->nullable();
+                $table->bigInteger('replacement')->nullable();;
+                $table->mediumText('camp_about_url')->nullable();
+                $table->integer('camp_about_nick_id')->nullable();
                 $table->integer('grace_period')->default(0);
             });
         }

--- a/database/migrations/2022_03_08_122027_create_camp_table.php
+++ b/database/migrations/2022_03_08_122027_create_camp_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateTopicTable extends Migration
+class CreateCampTable extends Migration
 {
     /**
      * Run the migrations.
@@ -13,13 +13,16 @@ class CreateTopicTable extends Migration
      */
     public function up()
     {
-        if (!Schema::hasTable('topic')) {
-            Schema::create('topic', function (Blueprint $table) {
+        if (!Schema::hasTable('camp')) {
+            Schema::create('camp', function (Blueprint $table) {
                 $table->id();
-                $table->string('namespace',250)->nullable();
-                $table->string('language',250)->nullable();
-                $table->mediumText('topic_name');
                 $table->integer('topic_num');
+                $table->integer('parent_camp_num');
+                $table->integer('camp_num');
+                $table->string('title',555);
+                $table->string('camp_name',555);
+                $table->mediumText('key_words')->nullable();
+                $table->string('language',250)->nullable();  
                 $table->longText('note',250)->nullable();
                 $table->integer('submitter_nick_id');
                 $table->integer('submit_time');
@@ -29,7 +32,8 @@ class CreateTopicTable extends Migration
                 $table->longText('object_reason')->nullable();
                 $table->integer('proposed');
                 $table->bigInteger('replacement');
-                $table->integer('namespace_id');
+                $table->mediumText('camp_about_url');
+                $table->integer('camp_about_nick_id');
                 $table->integer('grace_period')->default(0);
             });
         }
@@ -42,6 +46,6 @@ class CreateTopicTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('topic');
+        Schema::dropIfExists('camp');
     }
 }

--- a/database/migrations/2022_03_10_094735_create_support_table.php
+++ b/database/migrations/2022_03_10_094735_create_support_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateSupportTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (!Schema::hasTable('support')) {
+            Schema::create('suport', function (Blueprint $table) {
+                $table->increments('support_id');
+                $table->integer('nick_name_id');
+                $table->integer('delegate_nick_name_id')->default(0);
+                $table->integer('topic_num');
+                $table->integer('camp_num');
+                $table->integer('support_order')->default(1);
+                $table->integer('start')->default(0);
+                $table->integer('end')->default(0);  
+                $table->integer('flags')->nullable();
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('support');
+    }
+}

--- a/database/migrations/2022_03_10_094735_create_support_table.php
+++ b/database/migrations/2022_03_10_094735_create_support_table.php
@@ -14,7 +14,7 @@ class CreateSupportTable extends Migration
     public function up()
     {
         if (!Schema::hasTable('support')) {
-            Schema::create('suport', function (Blueprint $table) {
+            Schema::create('support', function (Blueprint $table) {
                 $table->increments('support_id');
                 $table->integer('nick_name_id');
                 $table->integer('delegate_nick_name_id')->default(0);

--- a/database/migrations/2022_03_15_062440_create_support_camp_procedure.php
+++ b/database/migrations/2022_03_15_062440_create_support_camp_procedure.php
@@ -1,0 +1,208 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+class CreateSupportCampProcedure extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+       
+       $procedure =  "DROP PROCEDURE IF EXISTS `user_support`;
+            CREATE  PROCEDURE `user_support`(IN `support_type` VARCHAR(10), IN `user_id` INT)
+            BEGIN
+
+                IF (support_type = 'direct') # QUERY TO GET USER'S DIRECT SUPPORT TOPICS AND CAMPS
+                THEN 
+                SELECT 
+                    t2.topic_num,
+                    t2.camp_num,
+                    t2.support_order,
+                    t1.title,
+                    t2.camp_name,
+                    t2.start,
+                    t2.support_id,
+                    t3.namespace_id
+                FROM
+                    (SELECT 
+                    a.topic_num,
+                    a.title 
+                    FROM
+                    camp a 
+                    INNER JOIN 
+                        (SELECT 
+                        topic_num,
+                        MAX(go_live_time) AS live_time 
+                        FROM
+                        camp 
+                        WHERE objector_nick_id IS NULL 
+                        AND camp_num = 1 
+                        AND go_live_time <= UNIX_TIMESTAMP(NOW()) 
+                        GROUP BY topic_num) b 
+                        ON a.topic_num = b.topic_num 
+                        AND a.go_live_time = b.live_time) t1,
+                    (SELECT 
+                    b.topic_num,
+                    b.camp_num,
+                    c.support_order,
+                    b.title AS topic_name,
+                    b.camp_name,
+                    c.start,
+                    c.support_id
+                    FROM
+                    (SELECT 
+                        a.* 
+                    FROM
+                        camp a 
+                        INNER JOIN 
+                        (SELECT 
+                            topic_num,
+                            camp_num,
+                            MAX(`go_live_time`) AS live_time 
+                        FROM
+                            camp 
+                        WHERE objector_nick_id IS NULL 
+                            AND go_live_time <= UNIX_TIMESTAMP(NOW()) 
+                        GROUP BY topic_num,
+                            camp_num) b 
+                        ON a.topic_num = b.topic_num 
+                        AND a.camp_num = b.camp_num 
+                        AND a.go_live_time = b.live_time) b,
+                    support c 
+                    WHERE b.camp_num = c.camp_num 
+                    AND b.topic_num = c.topic_num 
+                    AND c.nick_name_id IN 
+                    (SELECT 
+                        id 
+                    FROM
+                        nick_name 
+                    WHERE owner_code = 
+                        (SELECT 
+                        TO_BASE64 (CONCAT('Malia', user_id, 'Malia')))) 
+                    AND c.delegate_nick_name_id = 0 
+                    AND c.end = 0) t2,
+                (SELECT 
+                    topic_num,
+                    namespace_id 
+                FROM
+                    topic 
+                GROUP BY topic_num,
+                    namespace_id) t3 
+                WHERE t1.topic_num = t2.topic_num 
+                AND t1.topic_num = t3.topic_num 
+                ORDER BY t2.topic_num,
+                    t2.support_order ;
+                    
+                ELSEIF (support_type = 'delegate') #QUERY TO GET USER'S DELEGATE SUPPORT TOPICS AND CAMPS
+                THEN 
+                SELECT 
+                t2.topic_num,
+                t2.camp_num,
+                t2.support_order,
+                t1.title,
+                t2.camp_name,
+                t2.my_nick_name,
+                t2.delegated_to_nick_name,
+                t2.start,
+                t2.support_id,
+                t3.namespace_id,
+                delegate_nick_name_id,
+                delegate_user_id
+                FROM
+                (SELECT 
+                    a.topic_num,
+                    a.title 
+                FROM
+                    camp a 
+                    INNER JOIN 
+                    (SELECT 
+                        topic_num,
+                        MAX(go_live_time) AS live_time 
+                    FROM
+                        camp 
+                    WHERE objector_nick_id IS NULL 
+                        AND camp_num = 1 
+                        AND go_live_time <= UNIX_TIMESTAMP(NOW()) 
+                    GROUP BY topic_num) b 
+                    ON a.topic_num = b.topic_num 
+                    AND a.go_live_time = b.live_time) t1,
+                (SELECT 
+                    b.topic_num,
+                    b.camp_num,
+                    c.support_order,
+                    b.title AS topic_name,
+                    b.camp_name,
+                    d.nick_name AS my_nick_name,
+                    e.nick_name AS delegated_to_nick_name,
+                    c.start,
+                    c.support_id,
+                    c.delegate_nick_name_id,
+                    REPLACE(from_base64(e.owner_code),'Malia','') AS delegate_user_id
+                FROM
+                    (SELECT 
+                    a.* 
+                    FROM
+                    camp a 
+                    INNER JOIN 
+                        (SELECT 
+                        topic_num,
+                        camp_num,
+                        MAX(`go_live_time`) AS live_time 
+                        FROM
+                        camp 
+                        WHERE objector_nick_id IS NULL 
+                        AND go_live_time <= UNIX_TIMESTAMP(NOW()) 
+                        GROUP BY topic_num,
+                        camp_num) b 
+                        ON a.topic_num = b.topic_num 
+                        AND a.camp_num = b.camp_num 
+                        AND a.go_live_time = b.live_time) b,
+                    support c,
+                    nick_name d,
+                    nick_name e 
+                WHERE b.camp_num = c.camp_num 
+                    AND b.topic_num = c.topic_num 
+                    AND c.`nick_name_id` = d.id 
+                    AND c.`delegate_nick_name_id` = e.id 
+                    AND c.nick_name_id IN 
+                    (SELECT 
+                    id 
+                    FROM
+                    nick_name 
+                    WHERE owner_code = 
+                    (SELECT 
+                        TO_BASE64 (CONCAT('Malia', user_id, 'Malia')))) 
+                    AND c.delegate_nick_name_id != 0 
+                    AND c.end = 0) t2,
+                (SELECT 
+                    topic_num,
+                    namespace_id 
+                FROM
+                    topic 
+                GROUP BY topic_num,
+                    namespace_id) t3 
+                WHERE t1.topic_num = t2.topic_num 
+                AND t1.topic_num = t3.topic_num 
+                ORDER BY t2.topic_num,
+                t2.support_order;
+                END IF ;
+            END;;";
+
+        \DB::unprepared($procedure);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('support_camp_procedure');
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -25,6 +25,8 @@ class DatabaseSeeder extends Seeder
             AdsSeeder::class,
             ImageSeeder::class,
             CountrySeeder::class,
+            TopicSeeder::class,
+            SupportSeeder::class
         ]);
     }
 }

--- a/database/seeders/SupportSeeder.php
+++ b/database/seeders/SupportSeeder.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use DB;
+
+class SupportSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $support = array(
+
+            [
+                'nick_name_id' => 1,
+                'delegate_nick_name_id' => 0,
+                'topic_num' => 1,
+                'camp_num'  =>  2,
+                'support_order' => 1,
+            ],
+
+            [
+                'nick_name_id' => 1,
+                'delegate_nick_name_id' => 0,
+                'topic_num' => 1,
+                'camp_num'  =>  3,
+                'support_order' =>  2,
+            ],
+
+            [
+                'nick_name_id' => 1,
+                'delegate_nick_name_id' => 2,
+                'topic_num' => 2,
+                'camp_num'  =>  1,
+                'support_order' =>  1
+            ],
+
+        );
+
+        foreach($support as $sp){
+            DB::table('support')->insert([
+                [
+                    'nick_name_id' => $sp['nick_name_id'],
+                    'delegate_nick_name_id' => $sp['delegate_nick_name_id'],
+                    'topic_num'=> $sp['topic_num'],
+                    'camp_num' => $sp['camp_num'],
+                    'support_order' => $sp['support_order'],
+                    'start' => time(),
+                    'end' => 0,
+                ],
+            ]);
+        }
+    }
+}

--- a/database/seeders/TopicSeeder.php
+++ b/database/seeders/TopicSeeder.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use DB;
+
+class TopicSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $namespace = "General";
+        $namespaceId = "1";
+        $language = "English";
+        $topics = array(
+            [
+                'topic_name' => "Canonizer first topic",
+                'topic_num' => 1,
+                'namespace'=>$namespace,
+                'namespace_id'=>$namespaceId,
+                'language'=>$language,
+                'submit_time'=>time(),
+                'submitter_nick_id'=>1,
+                'go_live_time'=> time(),                
+                'camp' => array(
+                    [
+                        'topic_num' => "1",
+                        'title' => 'Canonizer first topic',
+                        'camp_name' => "Agreement",
+                        'camp_num' => "1",
+                        'parent_camp_num' => "",
+                     ],
+                    [
+                       'topic_num' => "1",
+                       'title' => '',
+                       'camp_name' => "First camp of first topic",
+                       'camp_num' => "2",
+                       'parent_camp_num' => "1",
+                    ],
+                    [
+                        'topic_num' => "1",
+                        'title' => '',
+                        'camp_name' => "Second camp of first topic",
+                        'camp_num' => "3",
+                        'parent_camp_num' => "1",
+                     ]
+                )
+            ],
+            [
+                'topic_name' => "Canonizer second topic",
+                'topic_num' => "2",
+                'namespace'=>$namespace,
+                'namespace_id'=>$namespaceId,
+                'language'=>$language,
+                'submit_time'=>time(),
+                'submitter_nick_id'=>1,
+                'go_live_time'=> time(),
+                'camp' => array(
+                    [
+                        'topic_num' => "2",
+                        'title' => 'Canonizer second topic',
+                        'camp_name' => "Agreement",
+                        'camp_num' => "1",
+                        'parent_camp_num' => "",
+                     ],
+                    [
+                       'topic_num' => "2",
+                       'title' => '',
+                       'camp_name' => "First camp of seconf topic",
+                       'camp_num' => "2",
+                       'parent_camp_num' => "1",
+                    ],
+                    [
+                        'topic_num' => "2",
+                        'title' => '',
+                        'camp_name' => "Second camp of seconf topic",
+                        'camp_num' => "3",
+                        'parent_camp_num' => "1",
+                     ]
+                )
+            ],
+
+        );
+
+
+        foreach($topics as $topic){
+            DB::table('topic')->insert([
+                [
+                    'topic_name' => $topic['topic_name'],
+                    'topic_num' => $topic['topic_num'],
+                    'namespace'=>$namespace,
+                    'namespace_id'=>$namespaceId,
+                    'language'=>$language,
+                    'submit_time'=>time(),
+                    'submitter_nick_id'=>1,
+                    'go_live_time'=> time(),
+                ],
+            ]);
+
+            foreach($topic['camp'] as $child){
+                //insert agreement camp in camp
+                DB::table('camp')->insert([
+                    [
+                        'title' => $topic['topic_name'],
+                        'camp_name' => $child['camp_name'],
+                        'topic_num' => $child['topic_num'],
+                        'camp_num' => $child['camp_num'],
+                        'language'=>$language,
+                        'submit_time'=>time(),
+                        'submitter_nick_id'=>1,
+                        'go_live_time'=> time(),
+                    ],
+                ]);
+            }
+
+            
+        }
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -55,6 +55,8 @@ $router->group(['prefix' => 'api/v3'], function() use ($router)
         $router->post('add-nick-name','NicknameController@addNickName');
         $router->post('update-nick-name/{id}','NicknameController@UpdateNickName');
         $router->get('get-nick-name-list','NicknameController@getNickNameList');
+        $router->get('get-direct-supported-camps','SupportController@getDirectSupportedCamps');
+        $router->get('get-delegated-supported-camps','SupportController@getDelegatedSupportedCamps');
     });
 
     $router->post('/ads','AdsController@getAds');

--- a/tests/SupportedCampsApiTest.php
+++ b/tests/SupportedCampsApiTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Laravel\Lumen\Testing\DatabaseMigrations;
+use Laravel\Lumen\Testing\DatabaseTransactions;
+use App\Models\User;
+
+class SupportedCampsApiTest extends TestCase
+{
+    public function testGuestUserCanoNotAccessDirectSupportedCampList()
+    {
+        print sprintf("Direct supported camps list can not be accessed by guest user %d %s", 401,PHP_EOL);
+       
+        $response = $this->call('GET', '/api/v3/get-direct-supported-camps', []);
+        $this->assertEquals(401, $response->status());       
+    }
+
+
+    public function testGuestUserCanoNotAccessDelegatedSupportedCampList()
+    {
+        print sprintf("Deleagted supported camps list can not be accessed by guest user %d %s", 401,PHP_EOL);
+       
+        $response = $this->call('GET', '/api/v3/get-delegated-supported-camps', []);
+        $this->assertEquals(401, $response->status());       
+    }
+}


### PR DESCRIPTION
This PR include API's for "Direct supported camps - can-215" & "Delegate supported camps - can-223"

Migration and seeder are there for table topic, camp and support.

There is also migration for stored procedure "user_support" which is used to fetch the "direct support camps" & "delegate supported camps" of logged in user.

@akuks  Please review and merge the PR