### PR TITLE
test cases and swagger documentation for camp statement history.Ticket # can-422

### DIFF
--- a/app/Http/Controllers/CampController.php
+++ b/app/Http/Controllers/CampController.php
@@ -272,7 +272,7 @@ class CampController extends Controller
                 $livecamp->nick_name=$livecamp->nickname->nick_name ?? trans('message.general.nickname_association_absence');
                 $parentCamp = Camp::campNameWithAncestors($livecamp,$filter);
                 $camp[]=$livecamp;
-                $indexs=['topic_num','camp_num','key_words','camp_about_url','nick_name'];
+                $indexs=['topic_num','camp_num','camp_name','key_words','camp_about_url','nick_name'];
                 $camp = $this->resourceProvider->jsonResponse($indexs, $camp);
                 $camp[0]['parentCamps']=$parentCamp;
             }

--- a/app/Http/Controllers/NewsFeedController.php
+++ b/app/Http/Controllers/NewsFeedController.php
@@ -166,10 +166,12 @@ class NewsFeedController extends Controller
         $display_text = $request->display_text;
         $submitterNickId = $request->submitter_nick_id;
         $link = $request->link;
+        $userId=$request->user()->id;
+        $userType=$request->user()->type;
         $availableForChild = $request->available_for_child;
         try {
             $newsFeed = NewsFeed::findOrFail($newsFeedId);
-            if ($newsFeed->author_id != $request->user()->id && $request->user()->type != "admin") {
+            if ($newsFeed->author_id != $userId && $userType != "admin") {
                 return $this->resProvider->apiJsonResponse(401, trans('message.general.permission_denied'), '', '');
             }
             $topicNum = $newsFeed->topic_num;
@@ -179,6 +181,7 @@ class NewsFeedController extends Controller
             $news = new NewsFeed();
             $news->topic_num =  $topicNum;
             $news->camp_num =  $campNum;
+            $news->author_id = $userId;
             $news->display_text = $display_text;
             $news->link = $link;
             $news->submitter_nick_id = $submitterNickId;

--- a/app/Http/Controllers/NewsFeedController.php
+++ b/app/Http/Controllers/NewsFeedController.php
@@ -57,7 +57,6 @@ class NewsFeedController extends Controller
      * )
      */
 
-
     public function getNewsFeed(Request $request, Validate $validate)
     {
         $validationErrors = $validate->validate($request, $this->rules->getNewsFeedValidationRules(), $this->validationMessages->getNewsFeedValidationMessages());
@@ -119,32 +118,32 @@ class NewsFeedController extends Controller
      *           mediaType="application/x-www-form-urlencoded",
      *           @OA\Schema(
      *               @OA\Property(
-     *                   property="topic_num",
-     *                   description="Topic number is required",
+     *                   property="newsfeed_id",
+     *                   description="ID of the newsfeed",
      *                   required=true,
      *                   type="integer",
      *               ),
      *               @OA\Property(
-     *                   property="camp_num",
-     *                   description="Camp number is required",
+     *                   property="submitter_nick_id",
+     *                   description="Submitter nick name id",
      *                   required=true,
      *                   type="integer",
      *               ),
      *               @OA\Property(
      *                  property="display_text",
-     *                  description="display text is required",
+     *                  description="Display text is required",
      *                  required=true,
      *                  type="array",
      *               ),
      *               @OA\Property(
      *                   property="link",
-     *                   description="link is required",
+     *                   description="Link is required",
      *                   required=true,
      *                   type="array",
      *               ),
      *               @OA\Property(
      *                   property="available_for_child",
-     *                   description="availability for child is required",
+     *                   description="Availability for child is required",
      *                   required=true,
      *                   type="array",
      *               ),
@@ -152,7 +151,8 @@ class NewsFeedController extends Controller
      *       )
      *   ), 
      *   @OA\Response(response=200, description="Success"),
-     *   @OA\Response(response=400, description="Error message")
+     *   @OA\Response(response=400, description="Error message"),
+     *   @OA\Response(response=401, description="Unauthenticated")
      * )
      */
 
@@ -231,19 +231,19 @@ class NewsFeedController extends Controller
      *               ),
      *               @OA\Property(
      *                  property="display_text",
-     *                  description="display text is required",
+     *                  description="Display text is required",
      *                  required=true,
      *                  type="string",
      *               ),
      *               @OA\Property(
      *                   property="link",
-     *                   description="link is required",
+     *                   description="Link is required",
      *                   required=true,
      *                   type="string",
      *               ),
      *               @OA\Property(
      *                   property="available_for_child",
-     *                   description="availability for child is required",
+     *                   description="Availability for child is required",
      *                   required=true,
      *                   type="boolean",
      *               ),
@@ -322,8 +322,8 @@ class NewsFeedController extends Controller
      *       )  
      *    ),
      *   @OA\Response(response=200, description="Success"),
-     *   @OA\Response(response=404, description="Record not found"),
-     *   @OA\Response(response=400, description="Error message")
+     *   @OA\Response(response=400, description="Error message"),
+     *   @OA\Response(response=401, description="Unauthenticated")
      *  )
      */
 
@@ -348,6 +348,41 @@ class NewsFeedController extends Controller
         }
     }
 
+    /**
+     * @OA\Post(path="/edit-camp-newsfeed",
+     *   tags={"Camp"},
+     *   summary="edit camp newsfeed",
+     *   description="This is used to get  a record for updating camp newsfeed.",
+     *   operationId="editCampNewsFeed",
+     *   @OA\Parameter(
+     *         name="Authorization",
+     *         in="header",
+     *         required=true,
+     *         description="Bearer {access-token}",
+     *         @OA\Schema(
+     *              type="Authorization"
+     *         ) 
+     *   ),
+     *   @OA\RequestBody(
+     *       required=true,
+     *       description="edit camp newsfeed",
+     *       @OA\MediaType(
+     *           mediaType="application/x-www-form-urlencoded",
+     *           @OA\Schema(
+     *               @OA\Property(
+     *                   property="id",
+     *                   description="Camp newsfeed id is required",
+     *                   required=true,
+     *                   type="integer",
+     *               )
+     *           )
+     *       )  
+     *    ),
+     *   @OA\Response(response=200, description="Success"),
+     *   @OA\Response(response=400, description="Error message"),
+     *   @OA\Response(response=401, description="Unauthenticated")
+     *  )
+     */
     public function editNewsFeed(Request $request, Validate $validate)
     {
         $validationErrors = $validate->validate($request, $this->rules->getNewsFeedEditValidationRules(), $this->validationMessages->getNewsFeedEditValidationMessages());

--- a/app/Http/Controllers/StatementController.php
+++ b/app/Http/Controllers/StatementController.php
@@ -119,6 +119,18 @@ class StatementController extends Controller
      *                  required=true,
      *                  type="integer",
      *              )
+     *               @OA\Property(
+     *                   property="as_of",
+     *                   description="As of filter type",
+     *                   required=false,
+     *                   type="string",
+     *               ),
+     *               @OA\Property(
+     *                   property="as_of_date",
+     *                   description="As of filter date",
+     *                   required=false,
+     *                   type="string",
+     *               )
      *         )
      *      )
      *   ),
@@ -135,6 +147,8 @@ class StatementController extends Controller
         $filter['topicNum'] = $request->topic_num;
         $filter['campNum'] = $request->camp_num;
         $filter['type'] = isset($request->type) ? $request->type :'all';
+        $filter['asOf'] = $request->as_of;
+        $filter['asOfDate'] = $request->as_of_date;
         $response = new stdClass();
         $response->statement = [];
         $response->ifIamSupporter = null;
@@ -159,8 +173,11 @@ class StatementController extends Controller
                         $starttime = time();
                         $endtime = $submittime + 60 * 60;
                         $interval = $endtime - $starttime;
+                        $val['objector_nick_name']=null;
                         if ($val->objector_nick_id !== NULL) {
                             $val['status'] = "objected";
+                             $val['objector_nick_name']=$val->objectorNickName->nick_name;
+                             $val->unsetRelation('objectorNickName');
                         } elseif ($currentTime < $val->go_live_time && $currentTime >= $val->submit_time) {
                             $val['status'] = "in_review";
                         } elseif ($currentLive != 1 && $currentTime >= $val->go_live_time) {

--- a/app/Http/Controllers/StatementController.php
+++ b/app/Http/Controllers/StatementController.php
@@ -95,6 +95,37 @@ class StatementController extends Controller
         }
     }
 
+    /**
+     * @OA\Post(path="/get-statement-history",
+     *   tags={"Camp"},
+     *   summary="get camp newsfeed",
+     *   description="This API is used to get camp statement history.",
+     *   operationId="getCampStatementHistory",
+     *   @OA\RequestBody(
+     *       required=true,
+     *       description="Get camp statement history",
+     *       @OA\MediaType(
+     *           mediaType="application/x-www-form-urlencoded",
+     *           @OA\Schema(
+     *              @OA\Property(
+     *                  property="topic_num",
+     *                  description="Topic number is required",
+     *                  required=true,
+     *                  type="integer",
+     *              ),
+     *              @OA\Property(
+     *                  property="camp_num",
+     *                  description="Camp number is required",
+     *                  required=true,
+     *                  type="integer",
+     *              )
+     *         )
+     *      )
+     *   ),
+     *   @OA\Response(response=200, description="Success"),
+     *   @OA\Response(response=400, description="Error message")
+     * )
+     */
     public function getStatementHistory(Request $request, Validate $validate)
     {
         $validationErrors = $validate->validate($request, $this->rules->getStatementHistoryValidationRules(), $this->validationMessages->getStatementHistoryValidationMessages());
@@ -103,6 +134,7 @@ class StatementController extends Controller
         }
         $filter['topicNum'] = $request->topic_num;
         $filter['campNum'] = $request->camp_num;
+        $filter['type'] = isset($request->type) ? $request->type :'all';
         $response = new stdClass();
         $response->statement = [];
         $response->ifIamSupporter = null;
@@ -140,7 +172,7 @@ class StatementController extends Controller
                         if ($interval > 0 && $val->grace_period > 0  && $request->user()->id != $submitterUserID) {
                             continue;
                         } else {
-                            array_push($response->statement, $val);
+                            ($filter['type']==$val['status'] || $filter['type']=='all') ? array_push($response->statement, $val) : null;    
                         }
                     }
                 }

--- a/app/Http/Request/ValidationMessages.php
+++ b/app/Http/Request/ValidationMessages.php
@@ -332,7 +332,9 @@ class ValidationMessages
         return([
             'topic_num.required' => trans('message.validation_get_statementHistory.topic_num_required'),
             'camp_num.required' => trans('message.validation_get_statementHistory.camp_num_required'),
-            'type.in' => trans('message.validation_get_statementHistory.type_in')
+            'type.in' => trans('message.validation_get_statementHistory.type_in'),
+            'as_of.in' => trans('message.validation_get_statementHistory.as_of_in'),
+            'as_of_date.required_if' => trans('message.validation_get_statementHistory.as_of_date_required'),
         ]);
     }
 

--- a/app/Http/Request/ValidationMessages.php
+++ b/app/Http/Request/ValidationMessages.php
@@ -331,7 +331,8 @@ class ValidationMessages
     {
         return([
             'topic_num.required' => trans('message.validation_get_statementHistory.topic_num_required'),
-            'camp_num.required' => trans('message.validation_get_statementHistory.camp_num_required')
+            'camp_num.required' => trans('message.validation_get_statementHistory.camp_num_required'),
+            'type.in' => trans('message.validation_get_statementHistory.type_in')
         ]);
     }
 

--- a/app/Http/Request/ValidationRules.php
+++ b/app/Http/Request/ValidationRules.php
@@ -295,6 +295,8 @@ class ValidationRules
             'topic_num' => 'required',
             'camp_num' => 'required',
             'type' => 'in:objected,in_review,live,old,all',
+            'as_of' => 'in:default,review,bydate',
+            'as_of_date' => 'required_if:as_of,bydate'
         ];
     }
 }

--- a/app/Http/Request/ValidationRules.php
+++ b/app/Http/Request/ValidationRules.php
@@ -222,6 +222,7 @@ class ValidationRules
             'as_of_date' => 'required_if:as_of,bydate'
         ]);
     }
+
     public function getTopicRecordValidationRules(): array
     {
         return ([
@@ -293,6 +294,7 @@ class ValidationRules
         return [
             'topic_num' => 'required',
             'camp_num' => 'required',
+            'type' => 'in:objected,in_review,live,old,all',
         ];
     }
 }

--- a/app/Models/Statement.php
+++ b/app/Models/Statement.php
@@ -69,4 +69,9 @@ class Statement extends Model
     public static function getHistory($topicnum, $campnum) {
         return self::where('topic_num', $topicnum)->where('camp_num', $campnum)->latest('submit_time')->get();
     }
+
+    public function objectorNickName() {
+        return $this->hasOne('App\Models\Nickname', 'id', 'objector_nick_id');
+    }
+
 }

--- a/resources/lang/en/message.php
+++ b/resources/lang/en/message.php
@@ -232,7 +232,8 @@ return [
     ],
     'validation_get_statementHistory' => [
         'topic_num_required' => "Topic number is required.",
-        'camp_num_required' => "Camp number is required"
+        'camp_num_required' => "Camp number is required",
+        'type_in' => "Please enter a valid type value (objected, in_review, live, old, all) or leave it empty",
     ],
     'validation_edit_newsfeed' => [
         'newsfeed_id_required' => "Newsfeed id is required.",

--- a/resources/lang/en/message.php
+++ b/resources/lang/en/message.php
@@ -234,6 +234,8 @@ return [
         'topic_num_required' => "Topic number is required.",
         'camp_num_required' => "Camp number is required",
         'type_in' => "Please enter a valid type value (objected, in_review, live, old, all) or leave it empty",
+        'as_of_in' => "Please enter a valid value (default,review,bydate) or leave it empty",
+        'as_of_date_required_if' => "Asof date is required in case of asof bydate",
     ],
     'validation_edit_newsfeed' => [
         'newsfeed_id_required' => "Newsfeed id is required.",

--- a/tests/DeleteNewsFeedApiTest.php
+++ b/tests/DeleteNewsFeedApiTest.php
@@ -48,7 +48,7 @@ class DeleteNewsFeedApiTest extends TestCase
     public function testDeleteNewsFeedApiStatus()
     {
         $data = [
-            'newsfeed_id' => 299
+            'newsfeed_id' => 238
         ];
         print sprintf("\n post NewsFeed ", 200, PHP_EOL);
         $user = User::factory()->make();
@@ -74,6 +74,4 @@ class DeleteNewsFeedApiTest extends TestCase
         );
         $this->assertEquals(401, $this->response->status());
     }
-
-
 }

--- a/tests/EditNewsFeedApiTest.php
+++ b/tests/EditNewsFeedApiTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use App\Models\User;
+
+class EditNewsFeedApiTest extends TestCase
+{
+    
+    /**
+     * Check Api with empty form data
+     * validation
+     */
+    public function testEditNewsFeedApiWithEmptyFormData()
+    {
+        print sprintf("Test with empty form data");
+        $user = User::factory()->make();
+        $this->actingAs($user)->post('/api/v3/edit-camp-newsfeed', []);
+        $this->assertEquals(400,  $this->response->status());
+    }
+
+    /**
+     * Check Api with empty data
+     * validation
+     */
+    public function testEditNewsFeedApiWithEmptyValues()
+    {
+        $emptyData = [
+            "newsfeed_id" => ""
+        ];
+        print sprintf("Test with empty values");
+        $user = User::factory()->make();
+        $this->actingAs($user)->post('/api/v3/edit-camp-newsfeed', $emptyData);
+        $this->assertEquals(400, $this->response->status());
+    }
+
+    /**
+     * Check Api with invalid data
+     * validation
+     */
+    public function testEditNewsFeedApiWithInvalidData()
+    {
+        $invalidData = [
+            "newsfeed_id" => "abc",
+        ];
+        print sprintf("Test with invalid values");
+        $user = User::factory()->make();
+        $this->actingAs($user)->post('/api/v3/edit-camp-newsfeed', $invalidData);
+        $this->assertEquals(400,  $this->response->status());
+    }
+
+    /**
+     * Check Api without auth
+     * validation
+     */
+    public function testEditNewsFeedWithoutUserAuth()
+    {
+        print sprintf("Test with empty form data");
+        $user = User::factory()->make();
+        $this->post('/api/v3/edit-camp-newsfeed', []);
+        $this->assertEquals(401,  $this->response->status());
+    }
+
+    /**
+     * Check Api response structure
+     */
+    public function testEditNewsFeedApiResponse()
+    {
+        $data = [
+            "newsfeed_id" => 123,
+        ]; 
+        print sprintf("\n Test News Feed API Response ", 200, PHP_EOL);
+        $user = User::factory()->make();
+        $this->actingAs($user)->post('/api/v3/edit-camp-newsfeed', $data);
+        $this->seeJsonStructure([
+            'status_code',
+            'message',
+            'error',
+            'data' => [
+                [
+                    'id',
+                    'display_text',
+                    'link',
+                    'available_for_child',
+                    'submitter_nick_id'
+                ]
+            ]
+        ]);
+    }
+}

--- a/tests/GetCampRecordApiTest.php
+++ b/tests/GetCampRecordApiTest.php
@@ -109,7 +109,8 @@ class GetCampRecordApiTest extends TestCase
                     'key_words',
                     'camp_about_url',
                     'nick_name',
-                    'parentCamps'
+                    'parentCamps',
+                    'camp_name'
                 ]
             ]
         ]);

--- a/tests/GetCampStatementHistoryTest.php
+++ b/tests/GetCampStatementHistoryTest.php
@@ -61,29 +61,13 @@ class GetCampStatementHistoryTest extends TestCase
             "camp_num" => "1",
             "type" => "all"
         ];
-        print sprintf("\n post NewsFeed ", 200, PHP_EOL);
+        print sprintf("\n with correct form data ", 200, PHP_EOL);
         $user = User::factory()->make();
         $this->actingAs($user)->post(
             '/api/v3/get-statement-history',
             $data
         );
         $this->assertEquals(200, $this->response->status());
-    }
-
-    /**
-     * Check Api without user Auth
-     */
-    public function testGetCampStatementHistorywithoutUserAuth()
-    {
-        $data = [
-            'newsfeed_id' => 299
-        ];
-        print sprintf("\n post NewsFeed ", 200, PHP_EOL);
-        $this->post(
-            '/api/v3/get-statement-history',
-            $data
-        );
-        $this->assertEquals(401, $this->response->status());
     }
 
      /**
@@ -96,7 +80,7 @@ class GetCampStatementHistoryTest extends TestCase
             "camp_num" => "1",
             "type" => "all"
         ];
-        print sprintf("\n Test News Feed API Response ", 200, PHP_EOL);
+        print sprintf("\n Test API Response ", 200, PHP_EOL);
         $user = User::factory()->make();
         $this->actingAs($user)->post('/api/v3/get-statement-history', $data);
         $this->seeJsonStructure([
@@ -115,4 +99,23 @@ class GetCampStatementHistoryTest extends TestCase
             ]
         ]);
     }
+
+    /**
+     * Check Api with as_of filter value bydate without as_of_date
+     * validation
+     */
+    public function testGetCampStatementHistoryApiWithoutFilterDate()
+    {
+        $invalidData = [
+            'topic_num' => 45,
+            'camp_num' => 1,
+            "type" => "all",
+            'as_of' => "bydate"
+        ];
+
+        print sprintf("Test with invalid values");
+        $response = $this->call('POST', '/api/v3/get-statement-history', $invalidData);
+        $this->assertEquals(400, $response->status());
+    }
+
 }

--- a/tests/GetCampStatementHistoryTest.php
+++ b/tests/GetCampStatementHistoryTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use App\Models\User;
+
+class GetCampStatementHistoryTest extends TestCase
+{
+
+    /**
+     * Check Api with empty form data
+     * validation
+     */
+    public function testGetCampStatementHistoryApiWithEmptyFormData()
+    {
+        print sprintf("Test with empty form data");
+        $user = User::factory()->make();
+        $this->actingAs($user)->post('/api/v3/get-statement-history', []);
+        $this->assertEquals(400, $this->response->status());
+    }
+
+    /**
+     * Check Api with empty values
+     * validation
+     */
+    public function testGetCampStatementHistoryApiWithEmptyValues()
+    {
+        $emptyData = [
+            "topic_num" => "",
+            "camp_num" => "",
+            "type" => ""
+        ];
+        print sprintf("Test with empty values");
+        $user = User::factory()->make();
+        $this->actingAs($user)->post('/api/v3/get-statement-history', $emptyData);
+        $this->assertEquals(400, $this->response->status());
+    }
+
+    /**
+     * Check Api with False values
+     * validation
+     */
+    public function testGetCampStatementHistoryApiWithFalseData()
+    {
+        $emptyData = [
+            "topic_num" => "abc",
+            "camp_num" => "abc",
+            "type" => "xyz"
+        ];
+        print sprintf("Test with id that dose not exist");
+        $user = User::factory()->make();
+        $this->actingAs($user)->post('/api/v3/get-statement-history', $emptyData);
+        $this->assertEquals(400, $this->response->status());
+    }
+
+    /**
+     * Check Api response code with correct data
+     */
+    public function testGetCampStatementHistoryApiStatus()
+    {
+        $data = [
+            "topic_num" => "320",
+            "camp_num" => "1",
+            "type" => "all"
+        ];
+        print sprintf("\n post NewsFeed ", 200, PHP_EOL);
+        $user = User::factory()->make();
+        $this->actingAs($user)->post(
+            '/api/v3/get-statement-history',
+            $data
+        );
+        $this->assertEquals(200, $this->response->status());
+    }
+
+    /**
+     * Check Api without user Auth
+     */
+    public function testGetCampStatementHistorywithoutUserAuth()
+    {
+        $data = [
+            'newsfeed_id' => 299
+        ];
+        print sprintf("\n post NewsFeed ", 200, PHP_EOL);
+        $this->post(
+            '/api/v3/get-statement-history',
+            $data
+        );
+        $this->assertEquals(401, $this->response->status());
+    }
+
+     /**
+     * Check Api response structure
+     */
+    public function testGetCampStatementHistoryApiResponse()
+    {
+        $data = [
+            "topic_num" => "320",
+            "camp_num" => "1",
+            "type" => "all"
+        ];
+        print sprintf("\n Test News Feed API Response ", 200, PHP_EOL);
+        $user = User::factory()->make();
+        $this->actingAs($user)->post('/api/v3/get-statement-history', $data);
+        $this->seeJsonStructure([
+            'status_code',
+            'message',
+            'error',
+            'data' => [
+                [
+                    'statement',
+                    'topic',
+                    'liveCamp',
+                    'parentCamp',
+                    'ifSupportDelayed',
+                    'ifIamSupporter'
+                ]
+            ]
+        ]);
+    }
+}

--- a/tests/GetNewsFeedApiTest.php
+++ b/tests/GetNewsFeedApiTest.php
@@ -53,7 +53,7 @@ class GetNewsFeedApiTest extends TestCase
     public function testGetNewsFeedApiResponse()
     {
         $data = [
-            'topic_num' => 2,
+            'topic_num' => 12,
             'camp_num' => 1
         ]; 
         print sprintf("\n Test News Feed API Response ", 200, PHP_EOL);
@@ -67,7 +67,10 @@ class GetNewsFeedApiTest extends TestCase
                     'id',
                     'display_text',
                     'link',
-                    'available_for_child'
+                    'available_for_child',
+                    'submitter_nick_name',
+                    'submit_time',
+                    'owner_flag'
                 ]
             ]
         ]);

--- a/tests/UpdateNewsFeedApiTest.php
+++ b/tests/UpdateNewsFeedApiTest.php
@@ -24,11 +24,11 @@ class UpdateNewsFeedApiTest extends TestCase
     public function testUpdateNewsFeedApiWithEmptyValues()
     {
         $emptyData = [
-            "topic_num" => "",
-            "camp_num" => "",
+            "newsfeed_id"=>"",
             "display_text" => "",
             "link" => "",
-            "available_for_child" => ""
+            "available_for_child" => "",
+            "submitter_nick_id"=>""
         ];
         print sprintf("Test with empty values");
         $user = User::factory()->make();
@@ -43,11 +43,11 @@ class UpdateNewsFeedApiTest extends TestCase
     public function testUpdateNewsFeedApiWithInvalidData()
     {
         $invalidData = [
-            "topic_num" => 2,
-            "camp_num" => 1,
-            "display_text" => ["xyz"],
-            "link" => ["facebook.com", "youtube.com"],
-            "available_for_child" => [1, 1]
+            "newsfeed_id"=>"abc",
+            "display_text" => "xyz",
+            "link" => "facebook.com",
+            "available_for_child" => 1,
+            "submitter_nick_id"=>"abc"
         ];
         print sprintf("Test with invalid values");
         $user = User::factory()->make();
@@ -61,11 +61,11 @@ class UpdateNewsFeedApiTest extends TestCase
     public function testUpdateNewsFeedApiStatus()
     {
         $data = [
-            "topic_num" => 2,
-            "camp_num" => 1,
-            "display_text" => ["xyz", "abc"],
-            "link" => ["facebook.com", "youtube.com"],
-            "available_for_child" => [1, 1]
+            "newsfeed_id"=>1,
+            "display_text" => "abc",
+            "link" => "facebook.com",
+            "available_for_child" =>  1,
+            "submitter_nick_id"=>1010
         ];
         print sprintf("\n Update NewsFeed ", 200, PHP_EOL);
         $user = User::factory()->make();


### PR DESCRIPTION
Swagger documentation and test cases revised for all newsFeed related APIs and added test cases and documentation for  camp statement history APIs. Also added type filter for camp statement history api