### PR TITLE
camp-subscription-modification

### DIFF
--- a/app/Http/Request/ValidationRules.php
+++ b/app/Http/Request/ValidationRules.php
@@ -336,7 +336,7 @@ class ValidationRules
             'topic_num' => 'required',
             'camp_num' => 'required',
             'checked' => 'required|boolean',
-            'subscription_id' => 'required_if:checked,false|exists:camp_subscription,id'
+            'subscription_id' => 'required_if:checked,false'
         ];
     }
 }


### PR DESCRIPTION
removed validation for checking subscription id exists or not. if passed null it treated it as value and validation always failed.