### PR TITLE
can-1386

### DIFF
--- a/app/Http/Controllers/TopicController.php
+++ b/app/Http/Controllers/TopicController.php
@@ -631,11 +631,8 @@ class TopicController extends Controller
         ])->whereNull('objector_nick_id')->get();
         if (count($inReviewTopicChanges)) {
             $topicIds = [];
-            foreach ($inReviewTopicChanges as $topic) {
-                $topicIds[] = $topic->id;
-            }
-            if (count($topicIds)) {
-                Topic::whereIn('id', $topicIds)->update(['go_live_time' => strtotime(date('Y-m-d H:i:s')) - 1]);
+            foreach ($inReviewTopicChanges as $key=>$topic) {
+                Topic::where('id', $topic->id)->update(['go_live_time' => strtotime(date('Y-m-d H:i:s')) - ($key+1)]);
             }
         }
     }


### PR DESCRIPTION
As we are updating go_live_time of all in-review topics to current time -1 second inside updateTopicsInReview function . this way all in-review topic have same go_live_time. so that is why we are unable to differentiate when we click on view_this version as  go_live_time is same for multiple records. Now we are subtracting time in increment so that we can differentiate.