### PR TITLE
#can-1472 Support is not getting removed from parent camp in below case

### DIFF
--- a/app/Helpers/Util.php
+++ b/app/Helpers/Util.php
@@ -438,6 +438,23 @@ class Util
         return;
     }
 
+     /**
+     * This function only work when we changes parent camp.
+     * @param int $campChangeId
+     */
+    public function parentCampChangedBasedOnCampChangeId($changeID) {
+        $camp = Camp::where('id', $changeID)->first();
+        if(!empty($camp)) {
+            $topic_num = $camp->topic_num;
+            $camp_num = $camp->camp_num;
+            $parent_camp_num = $camp->parent_camp_num;
+            $in_review_status=true;
+            //We have fetched new live camp record
+            $livecamp = Camp::getLiveCamp($topic_num,$camp_num);
+            $this->checkParentCampChanged($all, $in_review_status, $liveCamp);
+        }
+    }
+
     function remove_emoji($string)
     {
         $symbols = "\x{1F100}-\x{1F1FF}" // Enclosed Alphanumeric Supplement

--- a/app/Jobs/CanonizerService.php
+++ b/app/Jobs/CanonizerService.php
@@ -53,6 +53,10 @@ class CanonizerService implements ShouldQueue, Uniqueable
         if(array_key_exists('updateAll', $this->canonizerData)) {
             $updateAll = $this->canonizerData['updateAll'];
         }
+
+        if(!empty($this->canonizerData['campChangeID'])) {
+            Util::parentCampChangedBasedOnCampChangeId($this->canonizerData['campChangeID']);
+        }
         
         $requestBody = [
             'topic_num'     => $this->canonizerData['topic_num'],


### PR DESCRIPTION
Create a new parentCampChangedBasedOnCampChangeId that update camp and support after 24hrs and 1hrs based on dispatch job