### PR TITLE
CAN-API-502: Command to remove base URL from activity_log table

### DIFF
--- a/app/Console/Commands/DeleteURLFromActivityLogsCommand.php
+++ b/app/Console/Commands/DeleteURLFromActivityLogsCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\ActivityLog;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class DeleteURLFromActivityLogsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'logs:delete-base-url';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'This command will find and remove all the base URI from the activity logs table.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $ActivitiesWithBaseURL = (new ActivityLog())->where('properties->url', 'like', 'http%')->get();
+
+        $ActivitiesWithBaseURL = collect($ActivitiesWithBaseURL)->each(function ($item, $key) {
+            
+            $item->properties = json_decode($item->properties);
+            $parsedURL = parse_url($item->properties->url);
+
+            if (!empty($parsedURL['path'])) {
+                $item->properties->url = $parsedURL['path'];
+                if (isset($parsedURL['query']) && !empty($parsedURL['query'])) {
+                    $item->properties->url .= '?' . $parsedURL['query'];
+                }
+            }
+
+            $item->properties = json_encode($item->properties);
+            $item->save();
+            return true;
+        });
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -18,6 +18,7 @@ class Kernel extends ConsoleKernel
         'App\Console\Commands\UpdateS3FilePathInUploadTable',
         'App\Console\Commands\ReverseS3PathToFilePath',
         'App\Console\Commands\UpdateParseStatement',
+        'App\Console\Commands\DeleteURLFromActivityLogsCommand',
     ];
 
     /**


### PR DESCRIPTION
After PR merge please run below artisan command to update activity paths. For safety purpose please take backup of activity_logs table.
**php artisan logs:delete-base-url**