### PR TITLE
CAN-API-845: Meta Tag Seeder Updated

### DIFF
--- a/app/Http/Controllers/MetaTagController.php
+++ b/app/Http/Controllers/MetaTagController.php
@@ -125,6 +125,7 @@ class MetaTagController extends Controller
                 switch ($page_name) {
 
                     case 'TopicDetailsPage':
+                    case 'TopicAnimationPage':
                         $title = $topic->topic_name ?? "";
                         $title .= (strlen($title) > 0 ? ' / ' : '') . $camp->camp_name;
                         break;

--- a/database/seeders/MetaTagSeeder.php
+++ b/database/seeders/MetaTagSeeder.php
@@ -304,6 +304,15 @@ class MetaTagSeeder extends Seeder
                 'created_at' => date('Y-m-d H:i:s'),
                 'updated_at' => date('Y-m-d H:i:s'),
             ],
+            [
+                'page_name' => 'TopicAnimationPage',
+                'title' => 'Event Line | Canonizer',
+                'is_static' => 0,
+                'description' => '[Topic Description] limited to 160 characters.',
+                'submitter_nick_id' => null,
+                'created_at' => date('Y-m-d H:i:s'),
+                'updated_at' => date('Y-m-d H:i:s'),
+            ],  
         ];
     
         foreach ($data as $value) {

--- a/tests/MetaTagsTest.php
+++ b/tests/MetaTagsTest.php
@@ -33,6 +33,26 @@ class GetMetaTagsTest extends TestCase
         $this->actingAs($user)->post('/api/v3/meta-tags',$payload,$header);
         $this->assertEquals(200,  $this->response->status());
     }
+    
+    public function testGetMetatagsForDynamicPageWithValidData()
+    {
+        $payload = [
+            'page_name' => 'TopicDetailsPage',
+            "keys" => [
+                "topic_num" => 904,
+                "camp_num" => 1,
+            ]
+        ];
+        print sprintf("\nTest for dynamic pages with valid data");
+
+        $user = User::factory()->make();
+        $token = $user->createToken('TestToken')->accessToken;
+        $header = [];
+        $header['Accept'] = 'application/json';
+        $header['Authorization'] = 'Bearer ' . $token;
+        $this->actingAs($user)->post('/api/v3/meta-tags', $payload, $header);
+        $this->assertEquals(200,  $this->response->status());
+    }
 
     public function testGetMetatagsForDynamicPage()
     {


### PR DESCRIPTION
**Re-run the seeder first**
**php artisan db:seed --class=MetaTagSeeder**