### PR TITLE
fixed looses 3 paragraph issue on Submit Statement Update Based On This

### DIFF
--- a/app/Console/Commands/UpdateParseStatement.php
+++ b/app/Console/Commands/UpdateParseStatement.php
@@ -50,6 +50,7 @@ class UpdateParseStatement extends Command
                 $updateRecored = 1;
                 $WikiParser = new wikiParser;
                 $statement->parsed_value = $WikiParser->parse($statement->value);
+                $statement->parsed_value = str_replace("<br />","<p> </p>",$statement->parsed_value);
                 $statement->update();
                 echo "Total record found for update: " . $statement->count() . "\r\n";
                 echo "Updated record: " . $updateRecored . "\r\n";
@@ -59,6 +60,7 @@ class UpdateParseStatement extends Command
                 foreach($statements as $statement) { 
                     $WikiParser = new wikiParser;
                     $statement->parsed_value = $WikiParser->parse($statement->value);
+                    $statement->parsed_value = str_replace("<br />","<p> </p>",$statement->parsed_value);
                     $statement->update();
                     $updateRecored++;
                 }


### PR DESCRIPTION
Regarding the second point, we are debugging it:

2. Also, when I try to go back one version (the one that still has pictures) and select “Submit Statement Update Based On This” it looses the first 3 paragraphs after the picture?

Solution - 
php artisan update:parsevalue 5141

if this issue solve then run 
php artisan update:parsevalue 