### PR TITLE
Uploaded file paths changed to relative one

### DIFF
--- a/app/Console/Commands/UpdateFilePathsToRelativePaths.php
+++ b/app/Console/Commands/UpdateFilePathsToRelativePaths.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+use App\Models\ActivityLog;
+use App\Models\CommandHistory;
+use App\Models\Upload;
+use Carbon\Carbon;
+use Throwable;
+
+class UpdateFilePathsToRelativePaths extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'change:filepathstorelativepaths';
+
+    /**
+     * The console command made for updating the files full paths to relative paths
+     * in uploads table.
+     * @var string
+     */
+    protected $description = 'This command will change uploaded full file paths to relative paths.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $commandHistory = (new CommandHistory())->create([
+            'name' => $this->signature,
+            'parameters' => [],
+            'started_at' => Carbon::now()->timestamp,
+        ]);
+
+        try {
+            $getUploadedFiles = Upload::all();
+
+            foreach ($getUploadedFiles as $record) {
+                $relativePath = $this->convertToRelativePath($record->file_path);
+                
+                $record->update([
+                    'file_path' => $relativePath,
+                ]);
+            }
+
+            $this->info('S3 URLs converted to relative paths successfully.');
+
+        } catch (Throwable $th) {
+            dd("here", $th->getMessage());
+            $commandHistory->error_output = json_encode($th);
+            $commandHistory->save();
+        }
+
+        $commandHistory->finished_at = Carbon::now()->timestamp;
+        $commandHistory->save();
+    }
+
+    /**
+     * Convert an absolute S3 URL to a relative path.
+     *
+     * @param  string  $url
+     * @return string
+     */
+    private function convertToRelativePath($url)
+    {
+        // Define the base URLs you want to handle
+        $baseUrls = [
+            env('AWS_URL').'/',
+            env('AWS_PUBLIC_URL').'/'
+        ];
+
+        // Check each base URL and replace it with an empty string
+        foreach ($baseUrls as $baseUrl) {
+            if (strpos($url, $baseUrl) === 0) {
+                return str_replace($baseUrl, '', $url);
+            }
+        }
+
+        // If no matching base URL is found, return the original URL
+        return $url;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -27,7 +27,8 @@ class Kernel extends ConsoleKernel
         'App\Console\Commands\AddExsistingDataToElasticSearch',
         'App\Console\Commands\UpdateGracePeriodForOldLiveTopics',
         'App\Console\Commands\UpdateUserIdFromOwnerCode',
-        'App\Console\Commands\UpdateUserLastNameFromFullName'
+        'App\Console\Commands\UpdateUserLastNameFromFullName',
+        'App\Console\Commands\UpdateFilePathsToRelativePaths'
     ];
 
     /**

--- a/app/Http/Controllers/UploadController.php
+++ b/app/Http/Controllers/UploadController.php
@@ -143,7 +143,7 @@ class UploadController extends Controller
                     'file_id' => $fileShortCode,
                     'file_type'=> $file->getMimeType(),
                     'folder_id'=> (isset($all['folder_id']) && !empty($all['folder_id'])) ? $all['folder_id'] : null,
-                    'file_path' => $response['ObjectURL'],
+                    'file_path' => $filename,
                     'created_at' => time(),
                     'updated_at' => time()
                 ];


### PR DESCRIPTION
@akuks  Please follow the instructions before merging of this PR. 

Take the backup of uploads table on all environments. 

Then we need to run this below command to update all absolute paths to relative one.

` php artisan change:filepathstorelativepaths` 

Also there is one PR from front-end side needs to be merged named as can-issue-889