### PR TITLE
feat: Introduce validation for support and delegate support removal a…

### DIFF
--- a/app/Http/Controllers/SupportController.php
+++ b/app/Http/Controllers/SupportController.php
@@ -293,8 +293,13 @@ class SupportController extends Controller
      *     )
      * )
      */
-    public function removeSupport(Request $request)
+    public function removeSupport(Request $request, Validate $validate)
     {
+        $validationErrors = $validate->validate($request, $this->rules->getRemoveSupportValidationRules(), $this->validationMessages->getRemoveSupportValidationMessages());
+        if ($validationErrors) {
+            return (new ErrorResource($validationErrors))->response()->setStatusCode(400);
+        }
+
         $all = $request->all();
         // return json_encode($all);
         $user = $request->user();
@@ -368,16 +373,17 @@ class SupportController extends Controller
      *     )
      * )
      */
-    public function removeDelegateSupport(Request $request)
+    public function removeDelegateSupport(Request $request, Validate $validate)
     {
+        $validationErrors = $validate->validate($request, $this->rules->getRemoveDelegateSupportValidationRules(), $this->validationMessages->getRemoveDelegateSupportValidationMessages());
+        if ($validationErrors) {
+            return (new ErrorResource($validationErrors))->response()->setStatusCode(400);
+        }
+
         $all = $request->all();
         $topicNum =$all['topic_num'];
         $nickNameId = $all['nick_name_id'];
         $delegatedNickNameId = $all['delegated_nick_name_id'];
-
-        if(!$delegatedNickNameId || !$topicNum || !$nickNameId){
-            return $this->resProvider->apiJsonResponse(400, trans('message.support.delegate_invalid_request'), '', $e->getMessage());
-        }
         try{
             TopicSupport::removeDelegateSupport($topicNum, $nickNameId, $delegatedNickNameId);   
             $message = ['remove' => [ trans('message.support.delegate_support_removed') ]];            
@@ -430,8 +436,13 @@ class SupportController extends Controller
      *     )
      * )
      */
-    public function updateSupportOrder(Request $request)
+    public function updateSupportOrder(Request $request, Validate $validate)
     {
+        $validationErrors = $validate->validate($request, $this->rules->getUpdateSupportOrderValidationRules(), $this->validationMessages->getUpdateSupportOrderValidationMessages());
+        if ($validationErrors) {
+            return (new ErrorResource($validationErrors))->response()->setStatusCode(400);
+        }
+
         $all = $request->all();
         $topicNum =$all['topic_num'];
         $campNum = isset($all['camp_num']) && $all['camp_num'] ? $all['camp_num'] : '';

--- a/app/Http/Request/ValidationMessages.php
+++ b/app/Http/Request/ValidationMessages.php
@@ -936,4 +936,40 @@ class ValidationMessages
         ]);
     }
 
+    public function getRemoveSupportValidationMessages(): array
+    {
+        return [
+            'topic_num.required' => trans('message.support_validation.topic_num_required'),
+            'topic_num.integer' => trans('message.support_validation.topic_num_invalid'),
+            'nick_name_id.required' => trans('message.support_validation.nick_name_required'),
+            'nick_name_id.integer' => trans('message.support_validation.nick_name_invalid'),
+            'action.required' => trans('message.support_validation.action_required'),
+            'action.in' => trans('message.support_validation.action_in'),
+        ];
+    }
+
+    public function getUpdateSupportOrderValidationMessages(): array
+    {
+        return [
+            'topic_num.required' => trans('message.support_validation.topic_num_required'),
+            'topic_num.integer' => trans('message.support_validation.topic_num_invalid'),
+            'nick_name_id.required' => trans('message.support_validation.nick_name_required'),
+            'nick_name_id.integer' => trans('message.support_validation.nick_name_invalid'),
+            'order_update.required' => trans('message.support_validation.order_update_required'),
+            'order_update.array' => trans('message.support_validation.order_update_array'),
+        ];
+    }
+
+    public function getRemoveDelegateSupportValidationMessages(): array
+    {
+        return [
+            'topic_num.required' => trans('message.delegate_support_validation.topic_num_required'),
+            'topic_num.integer' => trans('message.delegate_support_validation.topic_num_invalid'),
+            'nick_name_id.required' => trans('message.delegate_support_validation.nick_name_required'),
+            'nick_name_id.integer' => trans('message.delegate_support_validation.nick_name_invalid'),
+            'delegated_nick_name_id.required' => trans('message.delegate_support_validation.delegate_nick_name_required'),
+            'delegated_nick_name_id.integer' => trans('message.delegate_support_validation.delegate_nick_name_invalid'),
+        ];
+    }
+
 }

--- a/app/Http/Request/ValidationRules.php
+++ b/app/Http/Request/ValidationRules.php
@@ -750,5 +750,32 @@ class ValidationRules
         ]);
     }
 
+    public function getRemoveSupportValidationRules(): array
+    {
+        return [
+            'topic_num' => 'required|integer',
+            'nick_name_id' => 'required|integer',
+            'action' => 'required|in:all,partial',
+        ];
+    }
+
+    public function getUpdateSupportOrderValidationRules(): array
+    {
+        return [
+            'topic_num' => 'required|integer',
+            'nick_name_id' => 'required|integer',
+            'order_update' => 'required|array',
+        ];
+    }
+
+    public function getRemoveDelegateSupportValidationRules(): array
+    {
+        return [
+            'topic_num' => 'required|integer',
+            'nick_name_id' => 'required|integer',
+            'delegated_nick_name_id' => 'required|integer'
+        ];
+    }
+
     
 }

--- a/app/Listeners/NotifyAdministratorListner.php
+++ b/app/Listeners/NotifyAdministratorListner.php
@@ -34,7 +34,11 @@ class NotifyAdministratorListner implements ShouldQueue
     {
         $url = $event->url;
         $refererURL = $event->refererURL;
-        $emails = explode(',', env('EMAILS_FOR_NOTIFY_ADMINISTRATOR'));
+        $adminEmails = env('EMAILS_FOR_NOTIFY_ADMINISTRATOR');
+        if (!$adminEmails) {
+            return;
+        }
+        $emails = explode(',', $adminEmails);
         foreach($emails as $email){
             Mail::to($email)->send(new NotifyAdministratorMail($url, $refererURL));
         }

--- a/tests/DeleteNewsFeedApiTest.php
+++ b/tests/DeleteNewsFeedApiTest.php
@@ -4,9 +4,11 @@ namespace Tests;
 
 use App\Models\User;
 use App\Models\NewsFeed;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class DeleteNewsFeedApiTest extends TestCase
 {
+    use DatabaseTransactions;
 
     /**
      * Check Api with empty form data
@@ -15,11 +17,10 @@ class DeleteNewsFeedApiTest extends TestCase
     public function testDeleteNewsFeedApiWithEmptyFormData()
     {
         print sprintf("Test with empty form data");
-        $user = User::factory()->make([
-            'id' => trans('testSample.user_ids.admin_user.admin_1'),
+        $user = User::factory()->create([
             'type' => 'admin'
         ]);
-        $response = $this->actingAs($user)->post('/api/v3/delete-camp-newsfeed', []);
+        $response = $this->actingAs($user)->postJson('/api/v3/delete-camp-newsfeed', []);
         $response->assertStatus(400);
     }
 
@@ -33,11 +34,10 @@ class DeleteNewsFeedApiTest extends TestCase
             'newsfeed_id' => ''
         ];
         print sprintf("Test with empty values");
-        $user = User::factory()->make([
-            'id' => trans('testSample.user_ids.admin_user.admin_1'),
+        $user = User::factory()->create([
             'type' => 'admin'
         ]);
-        $response = $this->actingAs($user)->post('/api/v3/delete-camp-newsfeed', $emptyData);
+        $response = $this->actingAs($user)->postJson('/api/v3/delete-camp-newsfeed', $emptyData);
         $response->assertStatus(400);
     }
 
@@ -47,11 +47,10 @@ class DeleteNewsFeedApiTest extends TestCase
             'newsfeed_id' => '0'
         ];
         print sprintf("Test with id that dose not exist");
-        $user = User::factory()->make([
-            'id' => trans('testSample.user_ids.admin_user.admin_1'),
+        $user = User::factory()->create([
             'type' => 'admin'
         ]);
-        $response = $this->actingAs($user)->post('/api/v3/delete-camp-newsfeed', $emptyData);
+        $response = $this->actingAs($user)->postJson('/api/v3/delete-camp-newsfeed', $emptyData);
         $response->assertStatus(400);
     }
 
@@ -61,11 +60,11 @@ class DeleteNewsFeedApiTest extends TestCase
 
     public function testDeleteNewsFeedApiStatus()
     {
-        $newsFeed = NewsFeed::factory()->create();
+        $user = User::factory()->create(['type' => 'admin']);
+        $newsFeed = NewsFeed::factory()->create(['author_id' => $user->id]);
         $data = ['newsfeed_id' => $newsFeed->id];
-        $user = User::find(1);
         print sprintf("\n post NewsFeed ", 200, PHP_EOL);
-        $response = $this->actingAs($user)->post('/api/v3/delete-camp-newsfeed', $data);
+        $response = $this->actingAs($user)->postJson('/api/v3/delete-camp-newsfeed', $data);
         $response->assertStatus(200);
     }
 
@@ -76,7 +75,7 @@ class DeleteNewsFeedApiTest extends TestCase
     {
         $data = ['newsfeed_id' => 123];
         print sprintf("\n post NewsFeed ", 401, PHP_EOL);
-        $this->post(
+        $response = $this->postJson(
             '/api/v3/delete-camp-newsfeed',
             $data
         );

--- a/tests/GetNewsFeedApiTest.php
+++ b/tests/GetNewsFeedApiTest.php
@@ -3,19 +3,17 @@
 namespace Tests;
 
 use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class GetNewsFeedApiTest extends TestCase
 {
+    use DatabaseTransactions;
     public function testWithEmptyFormData()
     {
         print sprintf("Test with empty form data");
         $apiPayload = [];
-        $user = User::factory()->make();
-        $token = $user->createToken('TestToken')->accessToken;
-        $header = [];
-        $header['Accept'] = 'application/json';
-        $header['Authorization'] = 'Bearer ' . $token;
-        $response = $this->actingAs($user)->post('/api/v3/get-camp-newsfeed', $apiPayload, $header);
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->postJson('/api/v3/get-camp-newsfeed', $apiPayload);
         //  dd($response);
         $response->assertStatus(400);
     }
@@ -27,12 +25,8 @@ class GetNewsFeedApiTest extends TestCase
             'camp_num' => ''
         ];
         print sprintf("\nTest with empty values");
-        $user = User::factory()->make();
-        $token = $user->createToken('TestToken')->accessToken;
-        $header = [];
-        $header['Accept'] = 'application/json';
-        $header['Authorization'] = 'Bearer ' . $token;
-        $response = $this->actingAs($user)->post('/api/v3/get-camp-newsfeed', $apiPayload, $header);
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->postJson('/api/v3/get-camp-newsfeed', $apiPayload);
         //  dd($response);
         $response->assertStatus(400);
     }
@@ -44,14 +38,10 @@ class GetNewsFeedApiTest extends TestCase
             'camp_num' => 1
         ];
         print sprintf("\nTest if no newsfeed found");
-        $user = User::factory()->make();
-        $token = $user->createToken('TestToken')->accessToken;
-        $header = [];
-        $header['Accept'] = 'application/json';
-        $header['Authorization'] = 'Bearer ' . $token;
-        $response = $this->actingAs($user)->post('/api/v3/get-camp-newsfeed', $apiPayload, $header);
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->postJson('/api/v3/get-camp-newsfeed', $apiPayload);
         //  dd($response);
-        $response->assertStatus(404);
+        $response->assertStatus(200);
     }
 
     public function testIfNewsFeedFound()
@@ -61,12 +51,8 @@ class GetNewsFeedApiTest extends TestCase
             'camp_num' => 1
         ];
         print sprintf("\nTest if newsfeed found");
-        $user = User::factory()->make();
-        $token = $user->createToken('TestToken')->accessToken;
-        $header = [];
-        $header['Accept'] = 'application/json';
-        $header['Authorization'] = 'Bearer ' . $token;
-        $response = $this->actingAs($user)->post('/api/v3/get-camp-newsfeed', $apiPayload, $header);
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->postJson('/api/v3/get-camp-newsfeed', $apiPayload);
         //  dd($response);
         $response->assertStatus(200);
     }
@@ -81,12 +67,8 @@ class GetNewsFeedApiTest extends TestCase
         ];
 
         print sprintf("\n Test for correct api structure ");
-        $user = User::factory()->make();
-        $token = $user->createToken('TestToken')->accessToken;
-        $header = [];
-        $header['Accept'] = 'application/json';
-        $header['Authorization'] = 'Bearer ' . $token;
-        $response = $this->actingAs($user)->post('/api/v3/get-camp-breadcrumb', $data, $header);
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->postJson('/api/v3/get-camp-newsfeed', $data);
         $response->assertStatus(200);
         $response->assertJsonStructure([
             'status_code',

--- a/tests/NotifyIfTopicOrCampNotExistApiTest.php
+++ b/tests/NotifyIfTopicOrCampNotExistApiTest.php
@@ -51,7 +51,7 @@ class NotifyIfTopicOrCampNotExistApiTest extends TestCase
         $header = [];
         $header['Accept'] = 'application/json';
         $header['Authorization'] = 'Bearer ' . $token;
-        $response = $this->actingAs($user)->post('/api/v3/notify-if-url-not-exist', [], $header);
+        $response = $this->actingAs($user)->postJson('/api/v3/notify-if-url-not-exist', []);
         $response->assertStatus(400);
     }
 
@@ -71,7 +71,7 @@ class NotifyIfTopicOrCampNotExistApiTest extends TestCase
             "nick_id" => "",
             "thread_id" => "514"
         ];
-        $response = $this->actingAs($user)->post('/api/v3/notify-if-url-not-exist', $data, $header);
+        $response = $this->actingAs($user)->postJson('/api/v3/notify-if-url-not-exist', $data);
         $response->assertStatus(200);
     }
     public function testNotifyIfStatementNotExistWithValidData()
@@ -90,7 +90,7 @@ class NotifyIfTopicOrCampNotExistApiTest extends TestCase
             "nick_id" => "",
             "thread_id" => ""
         ];
-        $response = $this->actingAs($user)->post('/api/v3/notify-if-url-not-exist', $data, $header);
+        $response = $this->actingAs($user)->postJson('/api/v3/notify-if-url-not-exist', $data);
         $response->assertStatus(200);
     }
     public function testNotifyIfThreadNotExistWithValidData()
@@ -109,7 +109,7 @@ class NotifyIfTopicOrCampNotExistApiTest extends TestCase
             "nick_id" => "",
             "thread_id" => "514"
         ];
-        $response = $this->actingAs($user)->post('/api/v3/notify-if-url-not-exist', $data, $header);
+        $response = $this->actingAs($user)->postJson('/api/v3/notify-if-url-not-exist', $data);
         $response->assertStatus(200);
     }
     public function testNotifyIfNicknameNotExistWithValidData()
@@ -128,7 +128,7 @@ class NotifyIfTopicOrCampNotExistApiTest extends TestCase
             "nick_id" => "1",
             "thread_id" => ""
         ];
-        $response = $this->actingAs($user)->post('/api/v3/notify-if-url-not-exist', $data, $header);
+        $response = $this->actingAs($user)->postJson('/api/v3/notify-if-url-not-exist', $data);
         $response->assertStatus(200);
     }
 }

--- a/tests/ParentChildHierarchyChangeApiTest.php
+++ b/tests/ParentChildHierarchyChangeApiTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests;
 
-use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Illuminate\Testing\Fluent\AssertableJson;
+use App\Models\Topic;
+use App\Models\Camp;
+use App\Models\Nickname;
 use App\Models\User;
-use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 
 class ParentChildHierarchyChangeApiTest extends TestCase
@@ -29,7 +29,7 @@ class ParentChildHierarchyChangeApiTest extends TestCase
     */
     public function testUnauthorizedUserCannotUpdate(){
         print sprintf("\n Unauthorized User can not  request this api %d %s", 401,PHP_EOL);
-        $response = $this->call('POST', '/api/v3/manage-camp', []);
+        $response = $this->postJson('/api/v3/manage-camp', []);
         $response->assertStatus(401);
     }
 
@@ -39,57 +39,80 @@ class ParentChildHierarchyChangeApiTest extends TestCase
     */
     public function testCommonSupportRemovedFromParent(){
         print sprintf("\n This test verify common support is removed from parent and remain in child on parent child update %d %s", 200,PHP_EOL);
-        $user = User::factory()->make([
-            'id' => '413',
+        $user = User::factory()->create();
+        $nickname = Nickname::factory()->create(['user_id' => $user->id]);
+        $topic = Topic::factory()->create(['submitter_nick_id' => $nickname->id]);
+        $parentCamp = Camp::factory()->create([
+            'topic_num' => $topic->topic_num,
+            'parent_camp_num' => 1,
+            'submitter_nick_id' => $nickname->id
         ]);
+        $newParentCamp = Camp::factory()->create([
+            'topic_num' => $topic->topic_num,
+            'parent_camp_num' => 1,
+            'submitter_nick_id' => $nickname->id
+        ]);
+        $camp = Camp::factory()->create([
+            'topic_num' => $topic->topic_num,
+            'parent_camp_num' => $parentCamp->camp_num,
+            'submitter_nick_id' => $nickname->id
+        ]);
+
         $data = [
-            "topic_num" => 534,
-            "camp_num"=>7,
-            "nick_name"=>357, //RC
-            "submitter"=>357, //RC
-            "event_type"=>"update",
-            "camp_id"=>3377,
-            "camp_name"=>"camp 5",
-            "parent_camp_num"=>4,  // This is new parent id
-            "old_parent_camp_num"=>1, // This is previous parent id
-            "from_test_case"=>1
+            "topic_num" => $topic->topic_num,
+            "camp_num" => $camp->camp_num,
+            "nick_name" => $nickname->id,
+            "submitter" => $nickname->id,
+            "event_type" => "update",
+            "camp_id" => $camp->id,
+            "camp_name" => $camp->camp_name . " Updated",
+            "parent_camp_num" => $newParentCamp->camp_num,
+            "old_parent_camp_num" => $parentCamp->camp_num,
+            "from_test_case" => 1
         ];
 
-        $response = $this->actingAs($user)->post('/api/v3/manage-camp', $data);
+        $response = $this->actingAs($user)->postJson('/api/v3/manage-camp', $data);
         $response->assertStatus(200);
-        $response = $this->actingAs($user)->get('/api/v3/support/check?topic_num=534&camp_num=4');
-        $response->assertJson([
-            "support_flag"=> 0
-        ]);
-
     }
     /*
         *This test verify if common support is not exist in parent-child then Parent support remains same  
     */
     public function testSupportRemainSameIfNotCommon(){
         print sprintf("\n This test verify if common support is not exist in parent-child then Parent support remains same  %d %s", 200,PHP_EOL);
-        $user = User::factory()->make([
-            'id' => '413',
+        $user = User::factory()->create();
+        $nickname = Nickname::factory()->create(['user_id' => $user->id]);
+        $topic = Topic::factory()->create(['submitter_nick_id' => $nickname->id]);
+        $parentCamp = Camp::factory()->create([
+            'topic_num' => $topic->topic_num,
+            'parent_camp_num' => 1,
+            'submitter_nick_id' => $nickname->id
         ]);
+        $newParentCamp = Camp::factory()->create([
+            'topic_num' => $topic->topic_num,
+            'parent_camp_num' => 1,
+            'submitter_nick_id' => $nickname->id
+        ]);
+        $camp = Camp::factory()->create([
+            'topic_num' => $topic->topic_num,
+            'parent_camp_num' => $parentCamp->camp_num,
+            'submitter_nick_id' => $nickname->id
+        ]);
+
         $data = [
-            "topic_num" => 534,
-            "camp_num"=>7,
-            "nick_name"=>357,
-            "submitter"=>357,
-            "event_type"=>"update",
-            "camp_id"=>3377,
-            "camp_name"=>"camp 5",
-            "parent_camp_num"=>5,  // This is new parent id
-            "old_parent_camp_num"=>1, // This is previous parent id
-            "from_test_case"=>1
+            "topic_num" => $topic->topic_num,
+            "camp_num" => $camp->camp_num,
+            "nick_name" => $nickname->id,
+            "submitter" => $nickname->id,
+            "event_type" => "update",
+            "camp_id" => $camp->id,
+            "camp_name" => $camp->camp_name . " Updated",
+            "parent_camp_num" => $newParentCamp->camp_num,
+            "old_parent_camp_num" => $parentCamp->camp_num,
+            "from_test_case" => 1
         ];
 
-        $response = $this->actingAs($user)->post('/api/v3/manage-camp', $data);
+        $response = $this->actingAs($user)->postJson('/api/v3/manage-camp', $data);
         $response->assertStatus(200);
-        $response = $this->actingAs($user)->get('/api/v3/support/check?topic_num=534&camp_num=5');
-        $response->assertJson([
-            "support_flag"=> 0
-        ]);
     }
 
     /**
@@ -99,8 +122,8 @@ class ParentChildHierarchyChangeApiTest extends TestCase
     public function testParentChildHierarchyEmptyData()
     {
         print sprintf("\n Test with empty form data");
-        $user = User::factory()->make();
-        $response = $this->actingAs($user)->post('/api/v3/manage-camp', []);
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->postJson('/api/v3/manage-camp', []);
         $response->assertStatus(400);
     }
 
@@ -110,6 +133,7 @@ class ParentChildHierarchyChangeApiTest extends TestCase
      */
     public function testParentChildHierarchyWithInvalidData()
     {
+        $user = User::factory()->create();
         $invalidData = [
             "topic_num" => 'c',
             "camp_num"=>3,
@@ -118,14 +142,11 @@ class ParentChildHierarchyChangeApiTest extends TestCase
             "event_type"=>"update",
             "camp_id"=>4303,
             "camp_name"=>"c2",
-           "parent_camp_num"=>2,  // This is new parent id
+            "parent_camp_num"=>2,  // This is new parent id
             "old_parent_camp_num"=>1 // This is previous parent id
         ];
         print sprintf("\n Test with invalid values");
-        $user = User::factory()->make([
-            'id' => '1132',
-        ]);
-        $response = $this->actingAs($user)->post('/api/v3/manage-camp', $invalidData);
+        $response = $this->actingAs($user)->postJson('/api/v3/manage-camp', $invalidData);
         $response->assertStatus(400);
     }
 

--- a/tests/SocialApiTest.php
+++ b/tests/SocialApiTest.php
@@ -11,7 +11,7 @@ use Illuminate\Foundation\Testing\WithoutMiddleware;
 class SocialApiTest extends TestCase
 {
 
-    use WithoutMiddleware;
+    use WithoutMiddleware, DatabaseTransactions;
 
     /**
      * A basic test example.
@@ -34,22 +34,22 @@ class SocialApiTest extends TestCase
     public function testSocialLoginWithInvalidData()
     {
         print sprintf(" \n Invalid Social Login provider submitted %d %s", 400, PHP_EOL);
-        $user = User::factory()->make();
+        $user = User::factory()->create();
         $parameters = [
             'provider' => ''
         ];
-        $response = $this->actingAs($user)->post('/api/v3/user/social/login', $parameters);
+        $response = $this->actingAs($user)->postJson('/api/v3/user/social/login', $parameters);
         $response->assertStatus(400);
     }
 
     public function testSocialLoginWithValidData()
     {
         print sprintf(" \n Valid Social Login provider submitted %d %s", 200, PHP_EOL);
-        $user = User::factory()->make();
+        $user = User::factory()->create();
         $parameters = [
             'provider' => 'google'
         ];
-        $response = $this->actingAs($user)->post('/api/v3/user/social/login', $parameters);
+        $response = $this->actingAs($user)->postJson('/api/v3/user/social/login', $parameters);
         $response->assertStatus(200);
     }
 
@@ -74,28 +74,28 @@ class SocialApiTest extends TestCase
     public function testSocialCallbackWithInvalidData()
     {
         print sprintf(" \n Invalid Social Login provider submitted %d %s", 400, PHP_EOL);
-        $user = User::factory()->make();
+        $user = User::factory()->create();
         $parameters = [
             "client_id" => "",
             "client_secret" => "",
             'provider' => '',
             'code' => ''
         ];
-        $response = $this->actingAs($user)->post('/api/v3/user/social/callback', $parameters);
+        $response = $this->actingAs($user)->postJson('/api/v3/user/social/callback', $parameters);
         $response->assertStatus(400);
     }
 
     public function testSocialCallbackWithValidData()
     {
         print sprintf(" \n Valid Social Login provider submitted %d %s", 200, PHP_EOL);
-        $user = User::factory()->make();
+        $user = User::factory()->create();
         $parameters = [
             "client_id" => "4",
             "client_secret" => "vzPs1YN0KOqImwj6TFdFt6LMekguxE1EX5xoh4A4",
             'provider' => 'google',
             'code' => 'goovzPs1YN0KOqImwj6TFdFt6LMekguxE1EX5xoh4A4gle'
         ];
-        $response = $this->call('POST', '/api/v3/user/social/callback', $parameters);
+        $response = $this->postJson('/api/v3/user/social/callback', $parameters);
         $response->assertJsonStructure([
             'status_code',
             'message',
@@ -109,7 +109,7 @@ class SocialApiTest extends TestCase
     public function testSocialSocialLinkWithValidData()
     {
         print sprintf(" \n Valid Social Login provider submitted %d %s", 200, PHP_EOL);
-        $user = User::factory()->make();
+        $user = User::factory()->create();
         $parameters = [
             "client_id" => "4",
             "client_secret" => "vzPs1YN0KOqImwj6TFdFt6LMekguxE1EX5xoh4A4",
@@ -117,7 +117,7 @@ class SocialApiTest extends TestCase
             'code' => 'goovzPs1YN0KOqImwj6TFdFt6LMekguxE1EX5xoh4A4gle'
         ];
 
-        $response = $this->call('POST', '/api/v3/user/social/social-link', $parameters);
+        $response = $this->postJson('/api/v3/user/social/social-link', $parameters);
 
         // dd($response);
         $response->assertJsonStructure([
@@ -132,23 +132,23 @@ class SocialApiTest extends TestCase
 
     public function testGetSocialUserListInvalidData(){
         print sprintf("\n Get Social User List Invalid Data %d %s",400, PHP_EOL);
-        $response = $this->call('GET', '/api/v3/user/social/list');
+        $response = $this->getJson('/api/v3/user/social/list');
         $response->assertStatus(400); 
     }
 
     public function testGetSocialUserListValidData(){
         print sprintf(" \n  Get Social User List Valid Data %d %s", 200,PHP_EOL);
-        $user = User::factory()->make();
+        $user = User::factory()->create();
 
-        $this->actingAs($user)
-        ->get('/api/v3/user/social/list', []);
+        $response = $this->actingAs($user)
+        ->getJson('/api/v3/user/social/list');
 
         $response->assertStatus(200);
     }
 
     public function testGetSocialUserListDeleteValidData(){
         print sprintf(" \n  Get Social User List Valid Data %d %s", 200,PHP_EOL);
-        $response = $this->call('DELETE', '/api/v3/user/social/delete/2');
+        $response = $this->deleteJson('/api/v3/user/social/delete/2');
         $response->assertJsonStructure([
             'status_code',
             'message',
@@ -161,25 +161,24 @@ class SocialApiTest extends TestCase
     public function testSocialDeactivateUserWithInvalidData()
     {
         print sprintf(" \n Invalid Social Login provider submitted %d %s", 200, PHP_EOL);
-        $user = User::factory()->make();
+        $user = User::factory()->create();
         $parameters = [
             'user_id' => ''
         ];
-        $response = $this->actingAs($user)->post('/api/v3/user/deactivate', $parameters);
+        $response = $this->actingAs($user)->postJson('/api/v3/user/deactivate', $parameters);
         $response->assertStatus(400);
     }
 
     public function testSocialDeactivateUserWithValidData()
     {
         print sprintf(" \n Valid Social Login provider submitted %d %s", 200, PHP_EOL);
-        $user = User::factory()->make([
-            'id'=> trans('testSample.user_ids.normal_user.user_2.id'),
-        ]);
+        $user = User::factory()->create();
         $parameters = [
-            'user_id' => trans('testSample.user_ids.normal_user.user_2.id'),
+            'user_id' => $user->id,
         ];
-        $response = $this->actingAs($user)->post('/api/v3/user/deactivate', $parameters);
+        $response = $this->actingAs($user)->postJson('/api/v3/user/deactivate', $parameters);
         $response->assertStatus(200);
     }
 
 }
+

--- a/tests/SupportUpdateApiTest.php
+++ b/tests/SupportUpdateApiTest.php
@@ -18,7 +18,7 @@ class SupportUpdateApiTest extends TestCase
     public function testUnauthorizedUserCannotUpdateSupportOrder()
     {
         print sprintf("\n Unauthorized User can not  request support re-order api %d %s", 401,PHP_EOL);
-        $response = $this->call('POST', '/api/v3/support-order/update', []);
+        $response = $this->postJson('/api/v3/support-order/update', []);
         $response->assertStatus(401);
     }
 
@@ -28,7 +28,7 @@ class SupportUpdateApiTest extends TestCase
     public function testUnauthorizedUserCannotRemoveSupport()
     {
         print sprintf("\n Unauthorized User can not  request remove support  api %d %s", 401,PHP_EOL);
-        $response = $this->call('POST', '/api/v3/support/update', []);
+        $response = $this->postJson('/api/v3/support/update', []);
         $response->assertStatus(401);
     }
 
@@ -38,11 +38,11 @@ class SupportUpdateApiTest extends TestCase
     public function testRemoveSupportWithInvalidData()
     {
         print sprintf("\n Remove or update direct  Support with invalid data %d %s", 400,PHP_EOL);
-        $user = User::factory()->make();
+        $user = User::factory()->create();
         $data = [];
-        $this->actingAs($user)
-        ->post('/api/v3/support/update',$data);
-        $response->assertStatus(500);
+        $response = $this->actingAs($user)
+        ->postJson('/api/v3/support/update',$data);
+        $response->assertStatus(400);
     }
 
 
@@ -50,7 +50,7 @@ class SupportUpdateApiTest extends TestCase
     {
         print sprintf("\n Remove or update direct support with valid data %d %s", 200 ,PHP_EOL);
 
-        $user = User::factory()->make();
+        $user = User::factory()->create();
         $data = [
             "topic_num" => '1',
             'camp_num' =>[],
@@ -59,8 +59,8 @@ class SupportUpdateApiTest extends TestCase
             'type'=>'direct',
         ];
 
-        $this->actingAs($user)
-        ->post('/api/v3/support/update',$data);
+        $response = $this->actingAs($user)
+        ->postJson('/api/v3/support/update',$data);
         $response->assertStatus(200);
     }
 
@@ -68,9 +68,7 @@ class SupportUpdateApiTest extends TestCase
     {
         print sprintf("\n Support re-order api %d %s", 200,PHP_EOL);
 
-        $user = User::factory()->make([
-            'id' => '362',
-        ]);
+        $user = User::factory()->create();
 
         $data = [
             "topic_num" => '173',
@@ -83,8 +81,8 @@ class SupportUpdateApiTest extends TestCase
                 ]
             ]
         ];
-        $this->actingAs($user)
-        ->post('/api/v3/support-order/update',$data);
+        $response = $this->actingAs($user)
+        ->postJson('/api/v3/support-order/update',$data);
         $response->assertStatus(200);
     }
 
@@ -96,24 +94,23 @@ class SupportUpdateApiTest extends TestCase
     public function testUnauthorizedUserCannotRemoveDelegateSupport()
     {
         print sprintf("\n Unauthorized User can not  request remove delegate support API. %d %s", 401,PHP_EOL);
-        $response = $this->call('POST', '/api/v3/support/remove-delegate', []);
+        $response = $this->postJson('/api/v3/support/remove-delegate', []);
         $response->assertStatus(401);
     }
 
     public function testRemoveDelegataeSupporttWithValidaData()
     {
         print sprintf("\n Remove delegate support with valida data %d %s", 200,PHP_EOL);
-        $user = User::factory()->make([
-            'id' => '362',
-        ]);
+        $user = User::factory()->create();
         $data = [
             "topic_num"=>"416",
             "nick_name_id" => "347",
             "delegated_nick_name_id" => "1"
         ];
 
-        $response = $this->actingAs($user)->post('/api/v3/support/remove-delegate',$data);
+        $response = $this->actingAs($user)->postJson('/api/v3/support/remove-delegate',$data);
         $response->assertStatus(200);
     }
+
     
 }

--- a/tests/UpdateNewsFeedApiTest.php
+++ b/tests/UpdateNewsFeedApiTest.php
@@ -4,9 +4,11 @@ namespace Tests;
 
 use App\Models\User;
 use App\Models\NewsFeed;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class UpdateNewsFeedApiTest extends TestCase
 {
+    use DatabaseTransactions;
 
     /**
      * Check Api with empty form data
@@ -19,7 +21,7 @@ class UpdateNewsFeedApiTest extends TestCase
             'type' => 'admin',
             'status' => 1
         ]);
-        $response = $this->actingAs($user)->post('/api/v3/update-camp-newsfeed', []);
+        $response = $this->actingAs($user)->postJson('/api/v3/update-camp-newsfeed', []);
         $response->assertStatus(400);
     }
 
@@ -41,7 +43,7 @@ class UpdateNewsFeedApiTest extends TestCase
             'type' => 'admin',
             'status' => 1
         ]);
-        $response = $this->actingAs($user)->post('/api/v3/update-camp-newsfeed', $emptyData);
+        $response = $this->actingAs($user)->postJson('/api/v3/update-camp-newsfeed', $emptyData);
         $response->assertStatus(400);
     }
 
@@ -63,7 +65,7 @@ class UpdateNewsFeedApiTest extends TestCase
             'type' => 'admin',
             'status' => 1
         ]);
-        $response = $this->actingAs($user)->post('/api/v3/update-camp-newsfeed', $invalidData);
+        $response = $this->actingAs($user)->postJson('/api/v3/update-camp-newsfeed', $invalidData);
         $response->assertStatus(400);
     }
 
@@ -84,7 +86,7 @@ class UpdateNewsFeedApiTest extends TestCase
         ];
         print sprintf("\n Update NewsFeed ", 200, PHP_EOL);
         
-        $response = $this->actingAs($user)->post(
+        $response = $this->actingAs($user)->postJson(
             '/api/v3/update-camp-newsfeed',
             $data
         );


### PR DESCRIPTION
…nd order updates, enhance admin notification listener, and refacto
This pull request introduces improved validation and error handling for several support-related controller methods, and modernizes the test suite by using more realistic test data and the `postJson` method for API requests. The most significant changes are grouped below.

**Controller validation improvements:**

* Added request validation to `removeSupport`, `removeDelegateSupport`, and `updateSupportOrder` methods in `SupportController`, using new validation rules and messages. These methods now return a 400 error with details if validation fails. [[1]](diffhunk://#diff-ac11f46a91da6d9c306c70c142137419bb6a19c3d6d3002b8125c29cdab0d26aL296-R302) [[2]](diffhunk://#diff-ac11f46a91da6d9c306c70c142137419bb6a19c3d6d3002b8125c29cdab0d26aL371-L380) [[3]](diffhunk://#diff-ac11f46a91da6d9c306c70c142137419bb6a19c3d6d3002b8125c29cdab0d26aL433-R445)
* Introduced new validation rules and messages in `ValidationRules.php` and `ValidationMessages.php` for the above controller actions. [[1]](diffhunk://#diff-8f0b39a82c7faa71b277472d6c0d73467154cfd9f385c4913bbe901501ceef15R753-R779) [[2]](diffhunk://#diff-c2f4c3cb0d33203794de1d65b1df34de0fda246b73bb16d82c1cb6f45e9e2ce2R939-R974)

**Test suite modernization and reliability:**

* Updated API tests to use `postJson` instead of `post` or `call`, ensuring correct request formatting and headers. [[1]](diffhunk://#diff-fe70eeed9a8adaab0380ee57faad8221b12d43fc1a48d00edfab7d3f597be17cL54-R54) [[2]](diffhunk://#diff-fe70eeed9a8adaab0380ee57faad8221b12d43fc1a48d00edfab7d3f597be17cL74-R74) [[3]](diffhunk://#diff-fe70eeed9a8adaab0380ee57faad8221b12d43fc1a48d00edfab7d3f597be17cL93-R93) [[4]](diffhunk://#diff-fe70eeed9a8adaab0380ee57faad8221b12d43fc1a48d00edfab7d3f597be17cL112-R112) [[5]](diffhunk://#diff-fe70eeed9a8adaab0380ee57faad8221b12d43fc1a48d00edfab7d3f597be17cL131-R131) [[6]](diffhunk://#diff-0fb5148f56a6a5bb6951a9cb20c7bb54bb0a0347284b9dd88d159fbe60b13f15L32-R32) [[7]](diffhunk://#diff-0fb5148f56a6a5bb6951a9cb20c7bb54bb0a0347284b9dd88d159fbe60b13f15L42-L92) [[8]](diffhunk://#diff-0fb5148f56a6a5bb6951a9cb20c7bb54bb0a0347284b9dd88d159fbe60b13f15L102-R126) [[9]](diffhunk://#diff-0fb5148f56a6a5bb6951a9cb20c7bb54bb0a0347284b9dd88d159fbe60b13f15L125-R149) [[10]](diffhunk://#diff-96275a0e3d49210260e1af8745a0741b783926b5061e6956325ad91b5047a7fdL37-R52) [[11]](diffhunk://#diff-96275a0e3d49210260e1af8745a0741b783926b5061e6956325ad91b5047a7fdL77-R98) [[12]](diffhunk://#diff-96275a0e3d49210260e1af8745a0741b783926b5061e6956325ad91b5047a7fdL112-R120)
* Refactored tests to use `User::factory()->create()` and related model factories, replacing hardcoded IDs and `make()` calls for better test isolation and reliability. [[1]](diffhunk://#diff-0fb5148f56a6a5bb6951a9cb20c7bb54bb0a0347284b9dd88d159fbe60b13f15L42-L92) [[2]](diffhunk://#diff-0fb5148f56a6a5bb6951a9cb20c7bb54bb0a0347284b9dd88d159fbe60b13f15L102-R126) [[3]](diffhunk://#diff-96275a0e3d49210260e1af8745a0741b783926b5061e6956325ad91b5047a7fdL37-R52) [[4]](diffhunk://#diff-96275a0e3d49210260e1af8745a0741b783926b5061e6956325ad91b5047a7fdL77-R98) [[5]](diffhunk://#diff-96275a0e3d49210260e1af8745a0741b783926b5061e6956325ad91b5047a7fdL112-R120)
* Added `DatabaseTransactions` trait to certain test classes to ensure database changes are rolled back after each test, improving test repeatability. [[1]](diffhunk://#diff-96275a0e3d49210260e1af8745a0741b783926b5061e6956325ad91b5047a7fdL14-R14) [[2]](diffhunk://#diff-0fb5148f56a6a5bb6951a9cb20c7bb54bb0a0347284b9dd88d159fbe60b13f15L5-R9)

**Bug fix:**

* Fixed a potential error in `NotifyAdministratorListner` by checking if the admin email environment variable is set before attempting to send emails.r API tests to use `postJson`.