### PR TITLE
Extract topics and total count from service response in  and wrap tok…

### DIFF
--- a/app/Http/Controllers/Api/v1/TopicController.php
+++ b/app/Http/Controllers/Api/v1/TopicController.php
@@ -51,8 +51,13 @@ class TopicController extends Controller
             $topicsFoundInMongo = Tree::count();
 
             if ($asofdateTime >= $today && $topicsFoundInMongo && !$commandStatus && in_array($algorithm, $algorithms)) {
-                $topics = TopicServiceFacade::getTopicsWithScore($namespaceId, $today, $algorithm, $skip, $pageSize, $filter, $nickNameIds, $search, $asof, $archive, $sort, $page, $topic_tags);
-                extract($topics);
+                $topicsResponse = TopicServiceFacade::getTopicsWithScore($namespaceId, $today, $algorithm, $skip, $pageSize, $filter, $nickNameIds, $search, $asof, $archive, $sort, $page, $topic_tags);
+                if (isset($topicsResponse['topics'])) {
+                    $topics = $topicsResponse['topics'];
+                    $totalCount = $topicsResponse['totalCount'] ?? 0;
+                } else {
+                    $topics = $topicsResponse;
+                }
             } else {
                 $topics = CampServiceFacade::getAllAgreementTopicCamps($pageSize, $skip, $asof, $asofdateTime, $namespaceId, $nickNameIds, $search, false, $archive, $sort, $topic_tags);
                 if ($page === 'browse') {

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -132,7 +132,7 @@ class UserController extends Controller
             $generateToken = json_decode($response->getContent());
             
             if ($response->getStatusCode() == 200) {
-                return (new SuccessResource($generateToken))->response()->setStatusCode(200);
+                return (new SuccessResource((object)['data' => $generateToken]))->response()->setStatusCode(200);
             }
             // Ensure status_code is set for ErrorResource
             if (!isset($generateToken->status_code)) {


### PR DESCRIPTION

This pull request introduces improvements to the structure of API responses for both the topic retrieval and client token generation endpoints. The changes focus on ensuring consistent and predictable response formats, making it easier for clients to handle API responses reliably.

**API Response Structure Improvements:**

* In `TopicController.php`, the response from `TopicServiceFacade::getTopicsWithScore` is now explicitly checked for the presence of a `topics` key. If present, both `topics` and `totalCount` are extracted; otherwise, the entire response is used as `topics`. This change prevents potential issues when the service returns different response shapes.

* In `UserController.php`, the successful response from the `clientToken` endpoint is now always wrapped in an object with a `data` property, ensuring a consistent response structure for clients consuming this endpoint.