### PR TITLE
fix: use type.keyword in ES aggregation to prevent search failure

### DIFF
--- a/app/Models/Search.php
+++ b/app/Models/Search.php
@@ -109,7 +109,7 @@ class Search extends Model
                     'aggs' => [
                         'type_counts' => [
                             'terms' => [
-                                'field' => 'type'
+                                'field' => 'type.keyword'
                             ],
                         ],
                     ],


### PR DESCRIPTION
The search aggregation was using 'type' (text field) which causes ElasticSearch to reject the entire query with "Text fields are not optimised for operations that require per-document field data". Changed to 'type.keyword' which is the correct subfield for aggregations on text fields with keyword mapping.