### PR TITLE
fix: fix ES client constructor - conditional auth and correct host fo…

### DIFF
--- a/app/Helpers/ElasticSearch.php
+++ b/app/Helpers/ElasticSearch.php
@@ -14,10 +14,11 @@ class ElasticSearch
         $host     = env('ELASTICSEARCH_HOSTS', 'localhost:9200');
         $username = env('ELASTICSEARCH_BASIC_AUTH_USERNAME', null);
         $password = env('ELASTICSEARCH_BASIC_AUTH_PASSWORD', null);
-        return $this->elasticsearchClient = ClientBuilder::create()
-            ->setBasicAuthentication($username, $password)
-            ->setHosts(['host' => $host])
-            ->build();
+        $clientBuilder = ClientBuilder::create()->setHosts([$host]);
+        if (!empty($username)) {
+            $clientBuilder->setBasicAuthentication($username, $password);
+        }
+        return $this->elasticsearchClient = $clientBuilder->build();
     }
 
     /**


### PR DESCRIPTION

- Only call setBasicAuthentication() when username is not empty. Previously always called with null credentials, causing ES to reject requests with empty Authorization header.
- Fix setHosts() to use indexed array [$host] instead of associative array ['host' => $host] which is not the correct format.

These bugs prevented real-time indexing via model boot() events from working, making elasticsearch:import the only way to populate the index.