### PR TITLE
fix: harden ES error handling to prevent blank search results

### DIFF
--- a/app/Helpers/ElasticSearch.php
+++ b/app/Helpers/ElasticSearch.php
@@ -32,7 +32,8 @@ class ElasticSearch
         }
 
         try {
-            $exists = $elasticsearch->indices()->exists(['index' => self::$indexName])->asBool();
+            $response = $elasticsearch->indices()->exists(['index' => self::$indexName]);
+            $exists = is_bool($response) ? $response : $response->asBool();
             if (!$exists) {
                 \Log::info("ElasticSearch index '" . self::$indexName . "' not found. Creating...");
                 $mapping = [
@@ -95,7 +96,7 @@ class ElasticSearch
                 $elasticsearch->indices()->create($mapping);
                 \Log::info("ElasticSearch index '" . self::$indexName . "' created successfully.");
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             \Log::error("ElasticSearch ensureIndexExists error: " . $e->getMessage());
         }
 
@@ -150,7 +151,7 @@ class ElasticSearch
             // Use the Bulk API to send the data in a batch
             $params = ['body' => $bulkData];
             $response = $elasticsearch->bulk($params);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             \Log::error("ElasticSearch ingestData error: " . $e->getMessage());
         }
         return;
@@ -180,7 +181,7 @@ class ElasticSearch
                 ];
                 $response = $elasticsearch->delete($delParam);
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             \Log::error("ElasticSearch deleteData error: " . $e->getMessage());
         }
         return;

--- a/app/Models/Search.php
+++ b/app/Models/Search.php
@@ -39,7 +39,9 @@ class Search extends Model
     {
         try {
             $elasticsearch = (new Elasticsearch())->elasticsearchClient;
-            ElasticSearch::ensureIndexExists($elasticsearch);
+            if ($elasticsearch) {
+                ElasticSearch::ensureIndexExists($elasticsearch);
+            }
             $size = intval($size) ? $size: 20 ;
             $from = $size * ((intval($from) ? : 1) - 1);
             $searchFields = ['type_value'];


### PR DESCRIPTION
- Make ensureIndexExists() compatible with both ES client v7 (returns bool) and v8/v9 (returns Response object with asBool())
- Change all catch blocks from \Exception to \Throwable to catch PHP Error types (TypeError, Error) that \Exception misses
- Guard ensureIndexExists() call in getSearchData() with null check
- Prevents silent failures that cause blank search results