### PR TITLE
Reconcile production server hand-patches back into development

### DIFF
--- a/app/Helpers/PostmarkMailer.php
+++ b/app/Helpers/PostmarkMailer.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Helpers;
+
+class PostmarkMailer
+{
+    public static function send(string $to, string $subject, string $htmlBody): bool
+    {
+        $token = env('POSTMARK_API_TOKEN');
+        $from  = env('MAIL_FROM_ADDRESS', 'jim@canonizer.com');
+
+        $payload = json_encode([
+            'From'     => $from,
+            'To'       => $to,
+            'Subject'  => $subject,
+            'HtmlBody' => $htmlBody,
+        ]);
+
+        $ch = curl_init('https://api.postmarkapp.com/email');
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_POST           => true,
+            CURLOPT_POSTFIELDS     => $payload,
+            CURLOPT_HTTPHEADER     => [
+                'Accept: application/json',
+                'Content-Type: application/json',
+                'X-Postmark-Server-Token: ' . $token,
+            ],
+            CURLOPT_TIMEOUT        => 15,
+        ]);
+
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        return $httpCode === 200;
+    }
+}

--- a/app/Helpers/TopicSupport.php
+++ b/app/Helpers/TopicSupport.php
@@ -366,19 +366,19 @@ class TopicSupport
 
                 DB::commit();
                 /* To update the Mongo Tree while adding support */
-                Util::dispatchJob($topic, $campNum, 1);
+                try { Util::dispatchJob($topic, $campNum, 1); } catch (\Throwable $e) { \Log::warning("dispatchJob failed: " . $e->getMessage()); }
 
                 //timeline start
                 $timeline_url = Util::getTimelineUrlgetTimelineUrl($topic->topic_num, $topic->topic_name, $campModel->camp_num, $campModel->camp_name, $topic->topic_name, "direct_support_added", null, $topic->namespace_id, $topic->submitter_nick_id);
 
-                Util::dispatchTimelineJob($topic->topic_num, $campModel->camp_num, 1, $nickName . " added direct support in camp - " . $campModel->camp_name, "direct_support_added", $campModel->camp_num, null, null, null, $asOfDefaultDate + 1, $timeline_url);
+                try { Util::dispatchTimelineJob($topic->topic_num, $campModel->camp_num, 1, $nickName . " added direct support in camp - " . $campModel->camp_name, "direct_support_added", $campModel->camp_num, null, null, null, $asOfDefaultDate + 1, $timeline_url); } catch (\Throwable $e) { \Log::warning("dispatchTimeline failed: " . $e->getMessage()); }
                 //timeline start
 
-                $subjectStatement = "has added their support to "; 
-                self::SendEmailToSubscribersAndSupporters($topicNum, $campNum, $nickNameId, $subjectStatement, 'add');
+                $subjectStatement = "has added their support to ";
+                try { self::SendEmailToSubscribersAndSupporters($topicNum, $campNum, $nickNameId, $subjectStatement, 'add'); } catch (\Throwable $e) { \Log::warning("SendEmail failed: " . $e->getMessage()); }
                 //GetPushNotificationToSupporter::pushNotificationToSupporter($user,$topicNum, $campNum, 'add', null, $nickName);
                 //log activity
-                self::logActivityForAddSupport($topicNum, $campNum, $nickNameId, null, $reason, $reason_summary, $citation_link);
+                try { self::logActivityForAddSupport($topicNum, $campNum, $nickNameId, null, $reason, $reason_summary, $citation_link); } catch (\Throwable $e) { \Log::warning("logActivity failed: " . $e->getMessage()); }
 
             }catch (Throwable $e) 
             {

--- a/app/Http/Controllers/StatementController.php
+++ b/app/Http/Controllers/StatementController.php
@@ -576,6 +576,14 @@ class StatementController extends Controller
 
             $statement->go_live_time = strtotime(date('Y-m-d H:i:s', strtotime('+1 days')));
 
+            // If the submitter is the only supporter of this camp, skip the grace
+            // period entirely — there is nobody else who could object, so the
+            // change can go live immediately.
+            if (in_array($eventType, ['create', 'update', 'edit']) && $ifIamSingleSupporter) {
+                $statement->go_live_time = time();
+                $statement->grace_period = 0;
+            }
+
             /** Dispatch job for the case when the statement is in grace period by user B,
              * so schedule a job that will run and update the tree
              * also this will update the grace period flag as well.
@@ -607,7 +615,14 @@ class StatementController extends Controller
                 }
             }
 
-            return $this->resProvider->apiJsonResponse(200, $message, (isset($all['is_draft']) && $all['is_draft'] ? [ "draft_record_id" => $statement->id] : ''), '');
+            return $this->resProvider->apiJsonResponse(
+                200,
+                $message,
+                (isset($all['is_draft']) && $all['is_draft'])
+                    ? ['draft_record_id' => $statement->id]
+                    : ['change_gone_live' => ($statement->go_live_time <= time())],
+                ''
+            );
         } catch (Exception $e) {
             return $this->resProvider->apiJsonResponse(400, trans('message.error.exception'), '', $e->getMessage());
         }

--- a/app/Http/Controllers/TopicController.php
+++ b/app/Http/Controllers/TopicController.php
@@ -2706,4 +2706,115 @@ class TopicController extends Controller
         // Util::mailSubscribersAndSupporters([], $subscribers, $link, $data);
     }
 
+    /**
+     * Soft-delete a topic. Permitted if the user is an admin
+     * OR owns the nickname that submitted the topic.
+     */
+    public function deleteTopic(Request $request)
+    {
+        $topicNum = $request->input('topic_num');
+        if (empty($topicNum)) {
+            return $this->resProvider->apiJsonResponse(400, 'topic_num is required', '', '');
+        }
+
+        $topic = Topic::where('topic_num', $topicNum)
+            ->where('is_disabled', 0)
+            ->orderBy('id', 'desc')
+            ->first();
+
+        if (!$topic) {
+            return $this->resProvider->apiJsonResponse(404, 'Topic not found', '', '');
+        }
+
+        $user = Auth::user();
+        $isAdmin = $user && $user->type === 'admin';
+        $nickIds = Nickname::getNicknamesIdsByUserId($user->id);
+        $isCreator = in_array($topic->submitter_nick_id, $nickIds);
+
+        if (!$isAdmin && !$isCreator) {
+            return $this->resProvider->apiJsonResponse(403, 'You do not have permission to delete this topic', '', '');
+        }
+
+        try {
+            Topic::where('topic_num', $topicNum)->update(['is_disabled' => 1]);
+
+            // Remove from canonizer-service MongoDB if configured
+            $appURL = env('CS_APP_URL');
+            $apiToken = env('API_TOKEN');
+            if (!empty($appURL) && !empty($apiToken)) {
+                $endpoint = $appURL . '/api/v1/tree/delete';
+                $headers = [
+                    'Content-Type:application/x-www-form-urlencoded',
+                    'X-Api-Token:' . $apiToken,
+                ];
+                Util::execute('POST', $endpoint, $headers, http_build_query(['topic_num' => $topicNum]));
+            }
+
+            return $this->resProvider->apiJsonResponse(200, 'Topic deleted', ['topic_num' => (int) $topicNum], '');
+        } catch (Exception $e) {
+            return $this->resProvider->apiJsonResponse(400, 'Failed to delete topic', '', $e->getMessage());
+        }
+    }
+
+    /**
+     * Admin or owner: restore a previously disabled topic.
+     */
+    public function restoreTopic(Request $request)
+    {
+        $topicNum = $request->input('topic_num');
+        if (empty($topicNum)) {
+            return $this->resProvider->apiJsonResponse(400, 'topic_num is required', '', '');
+        }
+
+        $topic = Topic::where('topic_num', $topicNum)->orderBy('id', 'desc')->first();
+        if (!$topic) {
+            return $this->resProvider->apiJsonResponse(404, 'Topic not found', '', '');
+        }
+
+        $user = Auth::user();
+        $isAdmin = $user && $user->type === 'admin';
+        $nickIds = Nickname::getNicknamesIdsByUserId($user->id);
+        $isCreator = in_array($topic->submitter_nick_id, $nickIds);
+
+        if (!$isAdmin && !$isCreator) {
+            return $this->resProvider->apiJsonResponse(403, 'You do not have permission to restore this topic', '', '');
+        }
+
+        try {
+            Topic::where('topic_num', $topicNum)->update(['is_disabled' => 0]);
+            return $this->resProvider->apiJsonResponse(200, 'Topic restored. Run tree:all on the canonizer-service to re-index.', ['topic_num' => (int) $topicNum], '');
+        } catch (Exception $e) {
+            return $this->resProvider->apiJsonResponse(400, 'Failed to restore topic', '', $e->getMessage());
+        }
+    }
+
+    /**
+     * Admin: list all topics (live + disabled) with namespace label.
+     */
+    public function adminListTopics(Request $request)
+    {
+        try {
+            $rows = DB::table('topic as t')
+                ->leftJoin('nick_name as n', 'n.id', '=', 't.submitter_nick_id')
+                ->leftJoin('namespace as ns', 'ns.id', '=', 't.namespace_id')
+                ->select(
+                    't.id',
+                    't.topic_num',
+                    't.topic_name',
+                    't.namespace_id',
+                    'ns.label as namespace_label',
+                    't.submitter_nick_id',
+                    'n.nick_name as submitter_nick_name',
+                    't.is_disabled',
+                    't.submit_time',
+                    't.go_live_time'
+                )
+                ->orderBy('t.topic_num', 'desc')
+                ->get();
+            return $this->resProvider->apiJsonResponse(200, 'Success', $rows, '');
+        } catch (Exception $e) {
+            return $this->resProvider->apiJsonResponse(400, 'Failed to list topics', '', $e->getMessage());
+        }
+    }
+
 }

--- a/app/Http/Middleware/Xss.php
+++ b/app/Http/Middleware/Xss.php
@@ -10,10 +10,20 @@ class Xss
     public function handle(Request $request, Closure $next)
     {
         $input = $request->all();
-        array_walk_recursive($input, function (&$input) {
-            $input = strip_tags($input);
+        if (empty($input)) {
+            $raw = $request->getContent();
+            if (!empty($raw)) {
+                $decoded = json_decode($raw, true);
+                if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+                    $input = $decoded;
+                }
+            }
+        }
+        array_walk_recursive($input, function (&$val) {
+            $val = strip_tags($val);
         });
         $request->merge($input);
+        $request->json()->replace($input);
         return $next($request);
     }
 }

--- a/app/Http/Request/ValidationRules.php
+++ b/app/Http/Request/ValidationRules.php
@@ -221,7 +221,7 @@ class ValidationRules
     public function getTopicStoreValidationRules(): array
     {
         return ([
-            'topic_name' => 'required|max:80',
+            'topic_name' => 'required|max:100',
             'namespace' => 'required',
             'create_namespace' => 'required_if:namespace,other|max:100',
             'nick_name' => 'required',

--- a/app/Http/Resources/Authentication/UserResource.php
+++ b/app/Http/Resources/Authentication/UserResource.php
@@ -20,7 +20,8 @@ class UserResource extends JsonResource
             "default_algo"    => $this->default_algo ?? null,
             "private_flags"   => $this->private_flags ?? null,
             "join_time"       => $this->join_time ?? time(),
-            "is_admin"       => $this->is_admin ?? null,
+            "type"            => $this->type ?? "user",
+            "is_admin"        => ($this->type === "admin"),
             "profile_picture" => !empty($this->profile_picture_path) ? $this->profile_picture_path : null
         ];
     }

--- a/app/Listeners/ForgotPasswordSendOtpListener.php
+++ b/app/Listeners/ForgotPasswordSendOtpListener.php
@@ -2,35 +2,33 @@
 
 namespace App\Listeners;
 
-use App\Mail\ForgotPasswordSendOtp;
 use App\Events\ForgotPasswordSendOtpEvent;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Support\Facades\Mail;
+use App\Helpers\PostmarkMailer;
+use Illuminate\Support\Facades\Log;
 
 class ForgotPasswordSendOtpListener
 {
-    /**
-     * Create the event listener.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
-    /**
-     * Handle the event.
-     *
-     * @param  \App\Events\ExampleEvent  $event
-     * @return void
-     */
     public function handle($event)
     {
         $user = $event->user;
-        $settingFlag = $event->settingFlag;
 
-        Mail::to($user->email)->send(new ForgotPasswordSendOtp($user,$settingFlag));
+        $name = htmlspecialchars($user->first_name . ' ' . $user->last_name);
+        $otp  = htmlspecialchars($user->otp);
+
+        $html = '<html><body style="font-family:Arial,sans-serif;max-width:600px;margin:0 auto;">'
+              . '<p>Hello ' . $name . ',</p>'
+              . '<p>Your one-time verification code for password reset is:</p>'
+              . '<p style="font-size:32px;font-weight:bold;color:#497BDF;letter-spacing:4px;">' . $otp . '</p>'
+              . '<p>If you have any issues, email <a href="mailto:support@canonizer.com">support@canonizer.com</a></p>'
+              . '<p>Sincerely,<br><span style="color:#497BDF;">The Canonizer Team</span></p>'
+              . '</body></html>';
+
+        $sent = PostmarkMailer::send($user->email, 'One Time Verification Code', $html);
+
+        if (!$sent) {
+            Log::error('PostmarkMailer failed to send forgot-password OTP to ' . $user->email);
+        }
     }
 }

--- a/app/Listeners/SendOtpListener.php
+++ b/app/Listeners/SendOtpListener.php
@@ -2,34 +2,37 @@
 
 namespace App\Listeners;
 
-
-use App\Mail\SendOtp;
 use App\Events\SendOtpEvent;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Support\Facades\Mail;
+use App\Helpers\PostmarkMailer;
+use Illuminate\Support\Facades\Log;
 
 class SendOtpListener
 {
-    /**
-     * Create the event listener.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        //
-    }
+    public function __construct() {}
 
-    /**
-    * Send Otp mail event
-    */
     public function handle($event)
     {
-        $user = $event->user;
+        $user        = $event->user;
         $settingFlag = $event->settingFlag;
 
-        Mail::to($user->email)->send(new SendOtp($user,$settingFlag));
+        $regLine = $settingFlag ? '' : '<p>Thank you for registering an account with canonizer.com</p>';
 
+        $name = htmlspecialchars($user->first_name . ' ' . $user->last_name);
+        $otp  = htmlspecialchars($user->otp);
+
+        $html = '<html><body style="font-family:Arial,sans-serif;max-width:600px;margin:0 auto;">'
+              . '<p>Hello ' . $name . ',</p>'
+              . $regLine
+              . '<p>Your one-time verification code is:</p>'
+              . '<p style="font-size:32px;font-weight:bold;color:#497BDF;letter-spacing:4px;">' . $otp . '</p>'
+              . '<p>If you have any issues, email <a href="mailto:support@canonizer.com">support@canonizer.com</a></p>'
+              . '<p>Sincerely,<br><span style="color:#497BDF;">The Canonizer Team</span></p>'
+              . '</body></html>';
+
+        $sent = PostmarkMailer::send($user->email, 'One Time Verification Code', $html);
+
+        if (!$sent) {
+            Log::error('PostmarkMailer failed to send OTP to ' . $user->email);
+        }
     }
 }

--- a/app/Models/Support.php
+++ b/app/Models/Support.php
@@ -67,7 +67,7 @@ class Support extends Model
                 return;
             }
             //echo $supportCount;
-            ElasticSearch::ingestData($id, $type, $typeValue, $topicNum, $campNum, $link, $goLiveTime, $namespace, $breadcrumb, $isLive = true, $isArchive=0, $statementNum, $nickNameId, $supportCount);
+            try { ElasticSearch::ingestData($id, $type, $typeValue, $topicNum, $campNum, $link, $goLiveTime, $namespace, $breadcrumb, $isLive = true, $isArchive=0, $statementNum, $nickNameId, $supportCount); } catch (\Throwable $e) { \Log::warning("ElasticSearch::ingestData failed: " . $e->getMessage()); }
 
         });
     }

--- a/database/migrations/2025_11_10_164249_camp_user_restrictions.php
+++ b/database/migrations/2025_11_10_164249_camp_user_restrictions.php
@@ -27,10 +27,14 @@ class CampUserRestrictions extends Migration
                 $table->enum('status', ['active','lifted','expired'])->default('active');
                 $table->timestamps();
 
-                // foreign keys 
-                $table->foreign('restricted_user_id')->references('id')->on('person')->cascadeOnDelete();
-                $table->foreign('restricted_by')->references('id')->on('person')->cascadeOnDelete();
-                $table->foreign('camp_id')->references('id')->on('camp')->cascadeOnDelete();
+                // foreign keys
+                // FKs disabled — fail to apply on production MySQL/InnoDB config
+                // (charset/collation mismatch with referenced tables); table is
+                // already in production without these FKs and the app code
+                // does not depend on them.
+                // $table->foreign('restricted_user_id')->references('id')->on('person')->cascadeOnDelete();
+                // $table->foreign('restricted_by')->references('id')->on('person')->cascadeOnDelete();
+                // $table->foreign('camp_id')->references('id')->on('camp')->cascadeOnDelete();
                 // $table->foreign('camp_num')->references('camp_num')->on('camp')->cascadeOnDelete();
                 // $table->foreign('topic_num')->references('topic_num')->on('camp')->cascadeOnDelete();
             });

--- a/database/migrations/2025_11_10_164613_create_camp_restriction_logs_table.php
+++ b/database/migrations/2025_11_10_164613_create_camp_restriction_logs_table.php
@@ -22,8 +22,11 @@ class CreateCampRestrictionLogsTable extends Migration
                 $table->text('notes')->nullable();
                 $table->timestamp('created_at')->useCurrent();
 
-                $table->foreign('restriction_id')->references('id')->on('camp_user_restrictions')->cascadeOnDelete();
-                $table->foreign('performed_by')->references('id')->on('person')->nullOnDelete();
+                // FKs disabled — fail to apply on production MySQL/InnoDB config
+                // (same root cause as 2025_11_10_164249_camp_user_restrictions).
+                // Table is already in production without these FKs.
+                // $table->foreign('restriction_id')->references('id')->on('camp_user_restrictions')->cascadeOnDelete();
+                // $table->foreign('performed_by')->references('id')->on('person')->nullOnDelete();
             });
         }
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -191,6 +191,8 @@ Route::group(['prefix' => 'v3'], function () {
         Route::post('agree-to-change', [TopicController::class, 'agreeToChange']);
         Route::post('/manage-topic', [TopicController::class, 'manageTopic']);
         Route::post('/edit-topic', [TopicController::class, 'editTopicRecord']);
+        Route::post('/delete-topic', [TopicController::class, 'deleteTopic']);
+        Route::post('/restore-topic', [TopicController::class, 'restoreTopic']);
         Route::get('/preferred-topic', [TopicController::class, 'preferredTopic']);
 
         Route::get('notification-list', [NotificationController::class, 'notificationList']);
@@ -208,6 +210,7 @@ Route::group(['prefix' => 'v3'], function () {
 
     // Admin Middleware group
     Route::group(['middleware' => 'admin'], function () {
+        Route::get('/admin/topics', [TopicController::class, 'adminListTopics']);
         Route::post('/edit-camp-newsfeed', [NewsFeedController::class, 'editNewsFeed']);
         Route::post('/store-camp-newsfeed', [NewsFeedController::class, 'storeNewsFeed']);
         Route::post('/update-camp-newsfeed', [NewsFeedController::class, 'updateNewsFeed']);


### PR DESCRIPTION
## Context

The production API server at 134.199.233.239 had ~16 modified files
sitting in its working tree that had never been committed back to git.
They were patches made directly on the server over time to fix issues
that surfaced in production. Any future deploy from `development`
would silently revert all of them.

This PR re-implements each of those patches as a clean, modern commit
on top of current `development` so the source of truth and the
production server agree. The server's literal diffs were *not* applied
verbatim because the server's HEAD (`271fdbb2`) is 13 commits behind
current `development` and a 3-way merge produced too many conflicts
to be safe; instead each commit re-implements the *intent* against
the current code.

## Patches included

1. **Replace SwiftMailer/SMTP OTP delivery with direct Postmark REST API**
   Production was hitting repeated `Connection timed out` errors against
   `smtp.postmarkapp.com:587` and OTP emails weren't reaching users.
   New `App\Helpers\PostmarkMailer` posts JSON to
   `api.postmarkapp.com/email` over HTTPS; both OTP listeners use it.
   Failures are logged but non-fatal so they don't poison the queue.

2. **Sanitize JSON request bodies in Xss middleware**
   The middleware previously only sanitized `$request->all()` (form
   data), which is empty for JSON requests, leaving every JSON-bodied
   endpoint without XSS protection. Now decodes the raw body, strips
   tags recursively, and writes back to both `$request` and
   `$request->json()`.

3. **Make post-support side effects best-effort in addDirectSupport**
   Wraps `Util::dispatchJob`, `Util::dispatchTimelineJob`, the
   subscriber email fan-out, and the activity log write in
   try/Log::warning so a downstream failure doesn't poison a successful
   support add.

4. **Comment out failing FKs in camp_user_restrictions migrations**
   The two camp-restriction migrations declared FKs that fail on the
   production InnoDB charset/collation config. Migrations are already
   in production without those FKs (manually patched on first deploy);
   this brings the source of truth in line.

5. **Skip grace period when submitter is sole camp supporter**
   When a statement edit's submitter is the only supporter of the camp,
   skip the 24-hour grace window — there's nobody else who could object.
   Also returns `change_gone_live` on the response so the frontend can
   show "Your change is live" vs "Your change is in review" without a
   follow-up GET.

6. **Add admin topic endpoints: deleteTopic, restoreTopic, adminListTopics**
   Three new endpoints that back the admin page:
   - `POST /v3/delete-topic`     soft-disable (admin or submitter)
   - `POST /v3/restore-topic`    re-enable     (admin or submitter)
   - `GET  /v3/admin/topics`     list all      (admin only)
   `deleteTopic` also fires a best-effort POST to the canonizer-service
   tree-delete endpoint when `CS_APP_URL`/`API_TOKEN` are set.

7. **Raise topic_name max length from 80 to 100 chars**
   The CreateNewTopic frontend has `maxLength={100}` on the topic-name
   input, so 81–100 char topics get rejected by the backend with a
   generic 400. Aligning the cap.

8. **Surface user `type` and derive `is_admin` from it in UserResource**
   The user model has migrated from a boolean `is_admin` column to a
   string `type` column (`'user'`, `'admin'`, etc.). The frontend admin
   gate uses `loggedInUser?.type === "admin"` but the auth response was
   still serializing only the legacy `is_admin`. Adds `type` and derives
   `is_admin` from it.

9. **Make ElasticSearch ingest best-effort in Support saved hook**
   When ES is unreachable, the exception was bubbling out of the
   Eloquent `saved` callback and aborting the surrounding DB write.
   Wraps `ingestData` in try/Log::warning so support rows land in MySQL
   even if the search index is temporarily down.

10. **Register routes for the new admin topic endpoints**
    Wires up `/delete-topic`, `/restore-topic`, `/admin/topics` in
    `routes/api.php`. The server's patch had added them to
    `routes/web.php`, but upstream has migrated all API routes to
    `routes/api.php`.

## Patches deliberately NOT included

- **CorsMiddleware default origin → wildcard** — security regression,
  needs a proper allowlist instead.
- **`thread_old` migration `subject` → nullable** — applied migration
  edit on a legacy table; low priority and a separate decision.
- **8 `.bak` / `.bak2` / `.bak3` files** — older snapshots of the same
  files; safe to delete on the server.
- **`.env.bak.1777669047`** — older `.env` snapshot containing a stale
  Postmark token. **Recommendation:** delete on the server and rotate
  the Postmark token since it sat in plaintext in the webroot.

## What this PR does *not* unblock

It does not make `development` deployable to the current production
server. Development has migrated to **Laravel 11 + PHP 8.4**; the
server is still on **Lumen 8 + PHP 8.1.34**. Deploying any branch of
`development` requires upgrading the server first. Plan for that
upgrade is being prepared separately. Merging this PR is still useful
because once the upgrade lands, deploys will pick up the
production-validated patches above.
