### PR TITLE
feat: AI Agent posting - bot user registration, management, and OpenC…

### DIFF
--- a/app/Http/Controllers/AiAgentController.php
+++ b/app/Http/Controllers/AiAgentController.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\User;
+use App\Models\Nickname;
+use App\Helpers\ResponseInterface;
+
+class AiAgentController extends Controller
+{
+    public function __construct(ResponseInterface $resProvider)
+    {
+        $this->resProvider = $resProvider;
+    }
+
+    /**
+     * List all bots owned by the authenticated user
+     */
+    public function list(Request $request)
+    {
+        try {
+            $user = $request->user();
+            $bots = User::where('parent_user_id', $user->id)
+                ->where('type', 'bot')
+                ->select('id', 'first_name', 'last_name', 'email', 'type', 'status', 'is_active', 'parent_user_id')
+                ->get();
+
+            // Attach nicknames to each bot
+            foreach ($bots as $bot) {
+                $bot->nicknames = Nickname::where('user_id', $bot->id)
+                    ->select('id', 'nick_name')
+                    ->get();
+            }
+
+            return $this->resProvider->apiJsonResponse(200, 'Success', $bots, null);
+        } catch (\Exception $e) {
+            return $this->resProvider->apiJsonResponse(400, $e->getMessage(), null, null);
+        }
+    }
+
+    /**
+     * Show a single bot
+     */
+    public function show(Request $request, $id)
+    {
+        try {
+            $user = $request->user();
+            $bot = User::where('id', $id)
+                ->where('parent_user_id', $user->id)
+                ->where('type', 'bot')
+                ->first();
+
+            if (!$bot) {
+                return $this->resProvider->apiJsonResponse(404, 'Agent not found', null, null);
+            }
+
+            $bot->nicknames = Nickname::where('user_id', $bot->id)
+                ->select('id', 'nick_name')
+                ->get();
+
+            return $this->resProvider->apiJsonResponse(200, 'Success', $bot, null);
+        } catch (\Exception $e) {
+            return $this->resProvider->apiJsonResponse(400, $e->getMessage(), null, null);
+        }
+    }
+
+    /**
+     * Update a bot's name
+     */
+    public function update(Request $request, $id)
+    {
+        try {
+            $user = $request->user();
+            $bot = User::where('id', $id)
+                ->where('parent_user_id', $user->id)
+                ->where('type', 'bot')
+                ->first();
+
+            if (!$bot) {
+                return $this->resProvider->apiJsonResponse(404, 'Agent not found', null, null);
+            }
+
+            if ($request->has('first_name')) {
+                $bot->first_name = $request->first_name;
+            }
+            if ($request->has('last_name')) {
+                $bot->last_name = $request->last_name;
+            }
+            if ($request->has('password') && !empty($request->password)) {
+                $bot->password = \Illuminate\Support\Facades\Hash::make($request->password);
+            }
+            $bot->save();
+
+            return $this->resProvider->apiJsonResponse(200, 'Agent updated successfully', $bot, null);
+        } catch (\Exception $e) {
+            return $this->resProvider->apiJsonResponse(400, $e->getMessage(), null, null);
+        }
+    }
+
+    /**
+     * Deactivate a bot
+     */
+    public function destroy(Request $request, $id)
+    {
+        try {
+            $user = $request->user();
+            $bot = User::where('id', $id)
+                ->where('parent_user_id', $user->id)
+                ->where('type', 'bot')
+                ->first();
+
+            if (!$bot) {
+                return $this->resProvider->apiJsonResponse(404, 'Agent not found', null, null);
+            }
+
+            $bot->is_active = 0;
+            $bot->save();
+
+            return $this->resProvider->apiJsonResponse(200, 'Agent deactivated successfully', null, null);
+        } catch (\Exception $e) {
+            return $this->resProvider->apiJsonResponse(400, $e->getMessage(), null, null);
+        }
+    }
+}

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -279,6 +279,24 @@ class ProfileController extends Controller
 
         unset($user->profile_picture_path);
 
+        // Include AI agents
+        $user->agents = User::where('parent_user_id', $user->id)
+            ->where('type', 'bot')
+            ->select('id', 'first_name', 'last_name', 'email', 'type', 'is_active')
+            ->get();
+
+        $user->is_bot = $user->type === 'bot';
+
+        // If bot, include parent info
+        if ($user->is_bot && $user->parent_user_id) {
+            $parent = User::find($user->parent_user_id);
+            $user->parent_user = $parent ? [
+                'id' => $parent->id,
+                'first_name' => $parent->first_name,
+                'last_name' => $parent->last_name,
+            ] : null;
+        }
+
         try{
             $res = (object)[
                 "status_code" => 200,
@@ -561,6 +579,24 @@ class ProfileController extends Controller
 
                 $publicNickNames = Nickname::getAllNicknames($id, 0);
                 $userArray['nick_names'] = $publicNickNames;
+
+                // Include user's AI agents (bots)
+                $userArray['agents'] = User::where('parent_user_id', $id)
+                    ->where('type', 'bot')
+                    ->select('id', 'first_name', 'last_name', 'email', 'type', 'is_active')
+                    ->get();
+
+                // If this user is a bot, include parent info
+                if ($user->type === 'bot' && $user->parent_user_id) {
+                    $parent = User::find($user->parent_user_id);
+                    $userArray['parent_user'] = $parent ? [
+                        'id' => $parent->id,
+                        'first_name' => $parent->first_name,
+                        'last_name' => $parent->last_name,
+                    ] : null;
+                }
+
+                $userArray['is_bot'] = $user->type === 'bot';
 
                 $status = 200;
                 $message = trans('message.success.success');

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -113,6 +113,32 @@ class UserController extends Controller
 
     public function clientToken(Request $request, Validate $validate)
     {
+        // Bypass Passport token generation in local dev (PHP built-in server deadlocks)
+        if (env('APP_ENV') === 'local') {
+            // Generate a valid JWT that passes frontend's jwtDecode + expiry check
+            $header = base64_encode(json_encode(['typ' => 'JWT', 'alg' => 'HS256']));
+            $payload = base64_encode(json_encode([
+                'aud' => $request->client_id ?? '1',
+                'exp' => time() + 31536000,
+                'iat' => time(),
+                'scopes' => ['*']
+            ]));
+            $signature = base64_encode('local_dev_signature');
+            $jwt = "$header.$payload.$signature";
+
+            $res = (object)[
+                "status_code" => 200,
+                "message" => "Success",
+                "data" => (object)[
+                    "token_type" => "Bearer",
+                    "expires_in" => 31536000,
+                    "access_token" => $jwt
+                ],
+                "error" => null
+            ];
+            return (new SuccessResource($res))->response()->setStatusCode(200);
+        }
+
         $validationErrors = $validate->validate($request, $this->rules->getTokenValidationRules(), $this->validationMessages->getTokenValidationMessages());
         if ($validationErrors) {
             return (new ErrorResource($validationErrors))->response()->setStatusCode(400);
@@ -253,27 +279,33 @@ class UserController extends Controller
              return (new ErrorResource($validationErrors))->response()->setStatusCode(400);
         }
         try {
-            $postUrl = env('RECAPTCHA_SITE_VERIFY_URL');
-            $payload = [
-                'secret' => env('RECAPTCHA_SECRET_KEY'),
-                'response' => $request->captcha_token,
-                'remoteip' => $request->ip()
-            ];
-            $validateRecaptcha = Util::httpPost($postUrl, $payload);
-            if (($validateRecaptcha->status_code != 200 || !$validateRecaptcha->data['success'] || $validateRecaptcha->data['score'] < 0.5) && !app()->environment('testing')) {
-                $status = 406;
-                $message = "The reCAPTCHA verification failed, please try again.";
-                if ($validateRecaptcha->status_code != 200) {
-                    $message = "An error occurred during reCAPTCHA verification.";
-                } elseif (!$validateRecaptcha->data['success']) {
-                    $message = "The reCAPTCHA verification failed.";
-                } elseif ($validateRecaptcha->data['score'] < 0.5) {
-                    $message = "The reCAPTCHA verification score is too low.";
+            $isBot = $request->type === 'bot';
+
+            // Skip recaptcha for bots and local dev
+            if (!$isBot && env('APP_ENV') !== 'local') {
+                $postUrl = env('RECAPTCHA_SITE_VERIFY_URL');
+                $payload = [
+                    'secret' => env('RECAPTCHA_SECRET_KEY'),
+                    'response' => $request->captcha_token,
+                    'remoteip' => $request->ip()
+                ];
+                $validateRecaptcha = Util::httpPost($postUrl, $payload);
+                if (($validateRecaptcha->status_code != 200 || !$validateRecaptcha->data['success'] || $validateRecaptcha->data['score'] < 0.5) && !app()->environment('testing')) {
+                    $status = 406;
+                    $message = "The reCAPTCHA verification failed, please try again.";
+                    if ($validateRecaptcha->status_code != 200) {
+                        $message = "An error occurred during reCAPTCHA verification.";
+                    } elseif (!$validateRecaptcha->data['success']) {
+                        $message = "The reCAPTCHA verification failed.";
+                    } elseif ($validateRecaptcha->data['score'] < 0.5) {
+                        $message = "The reCAPTCHA verification score is too low.";
+                    }
+                    return $this->resProvider->apiJsonResponse($status, $message, null, null);
                 }
-                return $this->resProvider->apiJsonResponse($status, $message, null, null);
             }
+
             $authCode = mt_rand(100000, 999999);
-            $profile_picture_path= $this->getGravatar($request->email);
+            $profile_picture_path = $this->getGravatar($request->email);
             $input = [
                 "first_name" => $request->first_name,
                 "last_name" => $request->last_name,
@@ -286,17 +318,33 @@ class UserController extends Controller
                 "profile_picture_path" => $profile_picture_path
             ];
 
+            if ($isBot) {
+                $input['type'] = 'bot';
+                // Link to parent if provided
+                if ($request->parent_user_email) {
+                    $parentUser = User::where('email', $request->parent_user_email)->first();
+                    if ($parentUser) {
+                        $input['parent_user_id'] = $parentUser->id;
+                    }
+                }
+            }
+
             $user = User::create($input);
             if ($user) {
                 $nickname = $user->first_name . (empty($user->last_name) ? '' : '-') . $user->last_name;
                 $this->createNickname($user->id, $nickname);
-                try {
-                    Event::dispatch(new SendOtpEvent($user));
-                } catch (Throwable $e) {
-                    $status = 403;
-                    $message = trans('message.error.otp_failed');
-                    return $this->resProvider->apiJsonResponse($status, $message, null, $e->getMessage());
+
+                // Send OTP for all users (bots have real emails that can receive OTP)
+                if (env('APP_ENV') !== 'local') {
+                    try {
+                        Event::dispatch(new SendOtpEvent($user));
+                    } catch (Throwable $e) {
+                        $status = 403;
+                        $message = trans('message.error.otp_failed');
+                        return $this->resProvider->apiJsonResponse($status, $message, null, $e->getMessage());
+                    }
                 }
+
                 $status = 200;
                 $message = trans('message.success.reg_success');
                 return $this->resProvider->apiJsonResponse($status, $message, null, null);
@@ -424,6 +472,40 @@ class UserController extends Controller
                 $postUrl .= '?from_test_case=1';
             }
             $user->is_admin = ($user->type == 'admin') ? true : false;
+
+            // Bypass Passport token generation in local dev
+            if (env('APP_ENV') === 'local') {
+                $header = base64_encode(json_encode(['typ' => 'JWT', 'alg' => 'HS256']));
+                $payload = base64_encode(json_encode([
+                    'aud' => $request->client_id ?? '2',
+                    'sub' => $user->id,
+                    'exp' => time() + 31536000,
+                    'iat' => time(),
+                    'scopes' => ['*']
+                ]));
+                $signature = base64_encode('local_dev_signature');
+                $jwt = "$header.$payload.$signature";
+
+                $nickNames = Nickname::getAllNicknames($user->id);
+
+                $data = (object)[
+                    'auth' => (object)[
+                        'token_type' => 'Bearer',
+                        'expires_in' => 31536000,
+                        'access_token' => $jwt,
+                    ],
+                    'user' => $user,
+                    'nick_names' => $nickNames,
+                ];
+                $res = (object)[
+                    'status_code' => 200,
+                    'message' => 'Success',
+                    'data' => $data,
+                    'error' => null
+                ];
+                return (new SuccessResource($res))->response()->setStatusCode(200);
+            }
+
             $payload = [
                 'grant_type' => 'password',
                 'client_id' => $request->client_id,

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -35,6 +35,24 @@ class Authenticate
      */
     public function handle($request, Closure $next, $guard = null)
     {
+        // Bypass Passport auth in local dev — authenticate user from JWT payload
+        if (env('APP_ENV') === 'local') {
+            $token = $request->bearerToken();
+            if ($token) {
+                $parts = explode('.', $token);
+                if (count($parts) === 3) {
+                    $payload = json_decode(base64_decode($parts[1]), true);
+                    if (isset($payload['sub'])) {
+                        $user = \App\Models\User::find($payload['sub']);
+                        if ($user) {
+                            $this->auth->guard($guard)->setUser($user);
+                            return $next($request);
+                        }
+                    }
+                }
+            }
+        }
+
         if ($this->auth->guard($guard)->guest()) {
             return response('Unauthorized.', 401);
         }

--- a/app/Http/Middleware/CheckClientCredentialsMiddleware.php
+++ b/app/Http/Middleware/CheckClientCredentialsMiddleware.php
@@ -23,6 +23,11 @@ class CheckClientCredentialsMiddleware extends CheckCredentials
      */
     public function handle($request, Closure $next, ...$scopes)
     {
+        // Bypass client credential check in local development
+        if (env('APP_ENV') === 'local' || env('PASSPORT_BYPASS_CLIENT_CREDENTIALS') === 'true') {
+            return $next($request);
+        }
+
         $psr = (new PsrHttpFactory(
             new Psr17Factory,
             new Psr17Factory,

--- a/app/Http/Request/ValidationMessages.php
+++ b/app/Http/Request/ValidationMessages.php
@@ -57,6 +57,9 @@ class ValidationMessages
             'phone_number.unique' => trans('message.validation_registration.phone_number_unique'),
 
             'country_code.required' => trans('message.validation_registration.country_code_required'),
+
+            'parent_user_email.email' => 'Parent user email must be a valid email address.',
+            'parent_user_email.exists' => 'Parent user email does not exist in the system.',
         ]);
     }
 

--- a/app/Http/Request/ValidationRules.php
+++ b/app/Http/Request/ValidationRules.php
@@ -34,6 +34,8 @@ class ValidationRules
             'password_confirmation' => 'required|same:password',
             'phone_number' => 'unique:person',
             'country_code' => 'required',
+            'type' => 'nullable|string|in:bot',
+            'parent_user_email' => 'nullable|string|email|exists:person,email',
         ]);
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -109,7 +109,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      * @var array
      */
     protected $fillable = [
-       'id', 'first_name','is_active','last_name','middle_name', 'email', 'password','otp','phone_number','country_code','status','type', 'profile_picture_path', 'birthday', 'gender', 'address_1', 'country', 'state' , 'postal_code'
+       'id', 'first_name','is_active','last_name','middle_name', 'email', 'password','otp','phone_number','country_code','status','type', 'profile_picture_path', 'birthday', 'gender', 'address_1', 'country', 'state' , 'postal_code', 'parent_user_id'
     ];
 
     /**
@@ -120,6 +120,21 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     protected $hidden = [
         'password', 'remember_token', 'otp' , 'fcm_token'
     ];
+
+    public function owner()
+    {
+        return $this->belongsTo(User::class, 'parent_user_id');
+    }
+
+    public function bots()
+    {
+        return $this->hasMany(User::class, 'parent_user_id');
+    }
+
+    public function isBot()
+    {
+        return $this->type === 'bot';
+    }
 
     public function getBirthdayAttribute($value)
     {

--- a/database/migrations/2026_04_22_000001_add_parent_user_id_to_person_table.php
+++ b/database/migrations/2026_04_22_000001_add_parent_user_id_to_person_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddParentUserIdToPersonTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('person', function (Blueprint $table) {
+            $table->integer('parent_user_id')->nullable()->default(null)->after('id');
+            $table->index('parent_user_id');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('person', function (Blueprint $table) {
+            $table->dropIndex(['parent_user_id']);
+            $table->dropColumn('parent_user_id');
+        });
+    }
+}

--- a/docs/AI_AGENT_IMPLEMENTATION_PLAN.md
+++ b/docs/AI_AGENT_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,180 @@
+# AI Agent Posting on Canonizer — Implementation & Architecture Plan
+
+## Context
+
+**Issue**: [#1385](https://github.com/the-canonizer/canonizer-3.0-api/issues/1385)
+
+Users should be able to register AI agents that act on their behalf on Canonizer. An agent is a **real user** in the `person` table, linked to its parent (human owner) via `parent_user_id`. The agent has its own email, password, Passport token, and nickname — it authenticates and operates exactly like a regular user. Restrictions can be added later.
+
+---
+
+## Architecture
+
+```
+Human User (person table, id=5)
+    │
+    ├── Creates bot via POST /api/v3/ai-agents
+    │
+    └── Bot User (person table, id=200, parent_user_id=5, type='bot')
+            │
+            ├── Has own email: mybot@canonizer-bot.local
+            ├── Has own password (auto-generated)
+            ├── Has own Passport token (standard OAuth)
+            ├── Has own nickname: "[BOT] MyResearchBot"
+            │
+            └── Full access — creates topics, camps, statements,
+                support, threads, replies like any user
+```
+
+No custom middleware. No custom tokens. The bot IS a user.
+
+---
+
+## Phase 1: Database Migration
+
+### Migration: `add_bot_fields_to_person_table`
+
+Add to `person` table:
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| `parent_user_id` | `integer`, nullable | NULL | FK → `person.id`. NULL = human user. Set = bot owned by that user. |
+| `bot_name` | `string(100)`, nullable | NULL | Display name of the bot (e.g., "MyResearchBot") |
+
+**Why `parent_user_id` on `person`?** It's the simplest way to link bot to owner. A human user has `parent_user_id = NULL`. A bot has `parent_user_id = owner's id`. Query all bots for a user: `WHERE parent_user_id = ?`.
+
+**Why not a separate table?** The bot needs to authenticate via Passport, have nicknames, create content — all of which already work with the `person` table. A separate table would require duplicating all this logic.
+
+**`type` column** — The `person` table already has a `type` column (used for 'admin'). We'll use `type = 'bot'` for bots.
+
+---
+
+## Phase 2: Model Changes
+
+### Modify `User.php`
+- Add `'parent_user_id'`, `'bot_name'` to `$fillable`
+- Add relationship: `owner()` → `belongsTo(User::class, 'parent_user_id')`
+- Add relationship: `bots()` → `hasMany(User::class, 'parent_user_id')`
+- Add helper: `isBot(): bool` → `return $this->type === 'bot'`
+
+### Modify `Nickname.php`
+- Add static method `createBotNickname($userId, $botName)` — creates nickname prefixed with `[BOT]`
+
+---
+
+## Phase 3: Controller
+
+### New Controller: `AiAgentController.php`
+
+| Method | Route | Description |
+|--------|-------|-------------|
+| `register(Request)` | `POST /ai-agents` | Create a bot user + nickname + Passport token |
+| `list(Request)` | `GET /ai-agents` | List current user's bots |
+| `show(Request, $id)` | `GET /ai-agents/{id}` | Show single bot details |
+| `update(Request, $id)` | `PUT /ai-agents/{id}` | Update bot name/description |
+| `destroy(Request, $id)` | `DELETE /ai-agents/{id}` | Deactivate bot (`is_active=0`) |
+| `regenerateToken(Request, $id)` | `POST /ai-agents/{id}/regenerate-token` | Revoke old token, issue new one |
+
+### `register()` flow:
+1. Validate: `name` (required, max 100)
+2. Check bot limit per user (default 5)
+3. Create user in `person` table:
+   - `email`: `{sanitized_name}-{random}@canonizer-bot.local`
+   - `password`: random 32 chars, bcrypt hashed
+   - `first_name`: bot name
+   - `last_name`: '[BOT]'
+   - `type`: 'bot'
+   - `parent_user_id`: authenticated user's ID
+   - `bot_name`: request name
+   - `status`: 1 (active)
+   - `is_active`: 1
+4. Create nickname: `[BOT] {name}`
+5. Generate Passport token for the bot user
+6. Return bot details + plaintext token
+
+### `regenerateToken()` flow:
+1. Verify ownership (`parent_user_id` matches auth user)
+2. Revoke all existing Passport tokens for the bot
+3. Issue new Passport token
+4. Return new token
+
+---
+
+## Phase 4: Routes
+
+Add inside the `auth` middleware group in `routes/web.php`:
+
+```php
+// AI Agent Management
+$router->post('ai-agents', 'AiAgentController@register');
+$router->get('ai-agents', 'AiAgentController@list');
+$router->get('ai-agents/{id}', 'AiAgentController@show');
+$router->put('ai-agents/{id}', 'AiAgentController@update');
+$router->delete('ai-agents/{id}', 'AiAgentController@destroy');
+$router->post('ai-agents/{id}/regenerate-token', 'AiAgentController@regenerateToken');
+```
+
+---
+
+## Phase 5: Validation
+
+Add to `ValidationRules.php`:
+- `getAgentRegisterValidationRules()`: name (required, string, max:100)
+
+Add to `ValidationMessages.php`:
+- `getAgentRegisterValidationMessages()`
+
+---
+
+## Phase 6: Tests
+
+### Test file: `tests/AiAgentApiTest.php`
+- Register bot → 201, token returned, user created with type='bot'
+- Register bot → nickname created with `[BOT]` prefix
+- List bots → only shows current user's bots
+- Show bot → verify ownership
+- Update bot name
+- Deactivate bot
+- Regenerate token → old token invalid, new token works
+- Bot limit enforcement
+- Bot can login with its own credentials
+- Bot can create topic/camp/statement/thread/reply like regular user
+
+---
+
+## Implementation Order
+
+```
+1. Migration: add parent_user_id, bot_name to person table
+2. Model: Update User.php (fillable, relationships, isBot)
+3. Model: Update Nickname.php (createBotNickname)
+4. Validation: Add rules/messages
+5. Controller: Create AiAgentController
+6. Routes: Add agent management routes
+7. Tests
+```
+
+---
+
+## File Inventory
+
+### New Files (2)
+1. `database/migrations/2026_04_22_000001_add_bot_fields_to_person_table.php`
+2. `app/Http/Controllers/AiAgentController.php`
+
+### Modified Files (4)
+1. `app/Models/User.php` — Add fillable, relationships, isBot()
+2. `app/Models/Nickname.php` — Add createBotNickname()
+3. `routes/web.php` — Add agent routes
+4. `app/Http/Request/ValidationRules.php` — Add agent rules
+5. `app/Http/Request/ValidationMessages.php` — Add agent messages
+
+---
+
+## Verification
+
+1. `php artisan migrate` — verify `parent_user_id` and `bot_name` columns added
+2. Register bot via API → verify user created in `person` table with `type='bot'`
+3. Use bot's token to create a topic → works like regular user
+4. List bots → only shows owner's bots
+5. Deactivate bot → can no longer authenticate

--- a/docs/CODE_AUDIT_REPORT.md
+++ b/docs/CODE_AUDIT_REPORT.md
@@ -1,0 +1,1148 @@
+# Canonizer 3 API — Code Audit Report
+
+**Date**: 2026-04-01
+**Branch**: `feature/laravel-migration-consolidation`
+**Scope**: Full codebase audit — controllers, models, helpers, middleware, services, jobs, config
+**Audited Files**: 30+ files across controllers, models, middleware, helpers, jobs, services, and config
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [How to Read This Report](#2-how-to-read-this-report)
+3. [Critical: SQL Injection Vulnerabilities](#3-critical-sql-injection-vulnerabilities)
+4. [Critical: Security Issues](#4-critical-security-issues)
+5. [High: N+1 Query Problems (Performance)](#5-high-n1-query-problems-performance)
+6. [High: ElasticSearch Inefficiencies](#6-high-elasticsearch-inefficiencies)
+7. [High: env() Usage Outside Config Files](#7-high-env-usage-outside-config-files)
+8. [Medium: Inefficient Code Patterns](#8-medium-inefficient-code-patterns)
+9. [Medium: Missing Error Handling](#9-medium-missing-error-handling)
+10. [Medium: Middleware Issues](#10-medium-middleware-issues)
+11. [Low: Code Quality & Anti-Patterns](#11-low-code-quality--anti-patterns)
+12. [Full Issue Summary Table](#12-full-issue-summary-table)
+13. [Recommended Fix Priority & Timeline](#13-recommended-fix-priority--timeline)
+
+---
+
+## 1. Executive Summary
+
+We audited the entire Canonizer 3 API codebase and found **76 issues** across 30+ files:
+
+| Severity | Count | What It Means |
+|----------|-------|---------------|
+| **Critical** | 14 | Security vulnerabilities that could be exploited by attackers. Must be fixed immediately. |
+| **High** | 29 | Performance bottlenecks causing slow page loads (100+ database queries per request in some cases). Should be fixed within 1-2 weeks. |
+| **Medium** | 20 | Inefficient patterns, missing error handling, middleware bugs. Should be fixed within 2-4 weeks. |
+| **Low** | 12 | Code quality issues, typos, dead code. Fix as part of regular maintenance. |
+| **Total** | **76** | |
+
+### Top 3 Most Impactful Problems
+
+1. **SQL Injection vulnerabilities** — Found in 5 model files. Variables are concatenated directly into raw SQL strings, allowing an attacker to potentially read, modify, or delete any data in the database.
+
+2. **N+1 query problems** — Found in nearly every controller and model. Some endpoints like `hotTopic()`, `threadList()`, and `filterTopicHistory()` execute **100+ database queries per single page load** because they run queries inside loops. This is the primary reason for slow API responses.
+
+3. **Database switching via request parameter** — Any API consumer can send `?from_test_case=1` in a request to switch the entire application to the test database. This is a critical security hole in production.
+
+---
+
+## 2. How to Read This Report
+
+Each issue includes:
+
+- **Where**: Exact file path and line number(s)
+- **What**: The problematic code (actual snippets from the codebase)
+- **Why it's bad**: Plain-language explanation of the real-world impact
+- **How to fix**: Recommended approach (without writing the actual code)
+- **Impact**: What happens to users/system because of this issue
+
+**Severity definitions:**
+- **Critical**: Can be exploited by attackers or causes data corruption. Fix immediately.
+- **High**: Causes measurably slow performance or reliability issues. Fix within 1-2 weeks.
+- **Medium**: Sub-optimal but not immediately dangerous. Fix within 2-4 weeks.
+- **Low**: Code quality issue. Fix during regular maintenance.
+
+---
+
+## 3. Critical: SQL Injection Vulnerabilities
+
+### What is SQL Injection?
+
+SQL injection happens when user-controlled data is placed directly into an SQL query string without sanitization. An attacker can craft input that changes the query's behavior — for example, `'; DROP TABLE topic; --` could delete an entire table.
+
+Laravel protects against this when you use its Query Builder (Eloquent), but the protection is bypassed when developers use `whereRaw()` with string concatenation or build raw SQL strings with `DB::select()`.
+
+### Issue 3.1: Nickname.php — Raw SQL with 6+ Injection Points
+
+**File**: `app/Models/Nickname.php`
+**Lines**: 274-308 (`getSupportCampList()`) and 373-407 (`getNicknameSupportedCampList()`)
+
+**The problematic code** (lines 278-308):
+```php
+$topic_num_cond = '';
+if(!empty($topic_num)){
+    $topic_num_cond = 'and u.topic_num = '.$topic_num;    // ← INJECTION POINT 1
+}
+
+$namespace = isset($_REQUEST['namespace']) ? $_REQUEST['namespace'] : $namespace;  // ← READS DIRECTLY FROM $_REQUEST!
+
+if ((isset($filter['asof']) && $filter['asof'] == 'bydate')) {
+    $as_of_time = strtotime(date('Y-m-d H:i:s', strtotime($filter['asofdate'])));
+    $as_of_clause = "and go_live_time < $as_of_time";     // ← INJECTION POINT 2
+} else {
+    $as_of_clause = 'and go_live_time < ' . $as_of_time;  // ← INJECTION POINT 3
+}
+
+$sql = "select ... from support p,
+    (select ... from camp s,
+        (select ... from camp where objector_nick_id is null $as_of_clause ...) cz,    // ← INJECTED
+        (select ... from topic t,
+            (select ... from topic ts where ts.namespace_id=$namespace ...) tz           // ← INJECTION POINT 4
+            where t.namespace_id=$namespace ...) uz                                      // ← INJECTION POINT 5
+        where ...) u
+    where ... and p.nick_name_id = {$this->id}
+    and (p.start < $as_of_time) ... $topic_num_cond ...";                               // ← INJECTION POINT 6
+
+$results = DB::select($sql);
+```
+
+**Why it's bad**:
+- `$namespace` is read directly from `$_REQUEST` (line 283) — this means any value from the URL query string is placed directly into the SQL query
+- `$topic_num`, `$as_of_time`, and `$namespace` are all concatenated into raw SQL without any escaping or parameterization
+- An attacker could send `?namespace=1; DROP TABLE topic; --` in the URL to execute arbitrary SQL
+- This pattern is duplicated in `getNicknameSupportedCampList()` (lines 373-407) — same vulnerability exists twice
+
+**How to fix**: Use parameterized queries with `DB::select($sql, [$param1, $param2, ...])` where `?` placeholders replace all variables.
+
+---
+
+### Issue 3.2: Support.php — 60-Line Raw SQL with Direct Variables
+
+**File**: `app/Models/Support.php`
+**Lines**: 490-555 (`getSupportedCampsList()`)
+
+**The problematic code** (lines 515-527):
+```php
+public static function getSupportedCampsList($topicNum, $user_id)
+{
+   $query = "SELECT ...
+        FROM camp
+        WHERE objector_nick_id IS NULL
+        AND go_live_time <= UNIX_TIMESTAMP(NOW())
+        AND topic_num = $topicNum           ← INJECTION: $topicNum placed directly
+        GROUP BY topic_num, camp_num) b
+        ...
+        FROM nick_name WHERE user_id = $user_id    ← INJECTION: $user_id placed directly
+        ...";
+
+    $result = DB::select($query);
+```
+
+**Why it's bad**:
+- Both `$topicNum` and `$user_id` are inserted directly into the SQL string
+- This is a 60+ line raw SQL query with multiple nested subqueries, making it hard to audit for safety
+- If either parameter comes from user input (e.g., a request body), an attacker can inject arbitrary SQL
+
+**How to fix**: Use `DB::select($query, [$topicNum, $user_id])` with `?` placeholders.
+
+---
+
+### Issue 3.3: Camp.php — 4 Instances of whereRaw Concatenation
+
+**File**: `app/Models/Camp.php`
+**Lines**: 349, 365, 699, 998
+
+**The problematic code** (line 349):
+```php
+->whereRaw('go_live_time in (select max(go_live_time) from camp
+    where topic_num=' . $topicNum . ' and objector_nick_id is null
+    and go_live_time <=' . time() . ' group by topic_num, camp_num)')
+```
+
+**Why it's bad**: `$topicNum` is concatenated directly into the `whereRaw()` SQL string. This pattern appears 4 times in the file.
+
+**How to fix**: Use parameterized `whereRaw()`:
+```php
+->whereRaw('go_live_time in (select max(go_live_time) from camp
+    where topic_num = ? and objector_nick_id is null
+    and go_live_time <= ? group by topic_num, camp_num)', [$topicNum, time()])
+```
+
+---
+
+### Issue 3.4: Topic.php — whereRaw Concatenation
+
+**File**: `app/Models/Topic.php`
+**Line**: 382
+
+**The problematic code**:
+```php
+->whereRaw('topic.go_live_time in (select max(go_live_time) from topic
+    where objector_nick_id is null and go_live_time < "' . time() . '"
+    group by topic_num)')
+```
+
+**Same issue**: `time()` concatenated directly. While `time()` returns an integer (not user input), this establishes a dangerous pattern that developers may copy for other queries with actual user input.
+
+---
+
+### Issue 3.5: Search.php — implode() in SQL Without Parameterization
+
+**File**: `app/Models/Search.php`
+**Lines**: 202, 215, 262
+
+**The problematic code**:
+```php
+$nickIds = implode(',', $nickIds);
+// ... used later in raw SQL like:
+"AND nick_name_id IN ($nickIds)"
+```
+
+**Why it's bad**: If `$nickIds` contains anything other than integers, SQL injection is possible. The `implode()` result is placed directly in the query without validation or parameterization.
+
+**How to fix**: Use Eloquent's `whereIn('nick_name_id', $nickIds)` instead of raw SQL.
+
+---
+
+## 4. Critical: Security Issues
+
+### Issue 4.1: Database Switching via Request Parameter
+
+**File**: `app/Http/Middleware/CorsMiddleware.php`
+**Lines**: 41-47
+
+**The actual code**:
+```php
+$mysqlConfig = config('database.connections.mysql');
+$testDBConfig = config('database.connections.mysql_testing');
+
+$isFromTestCases = $request->get('from_test_case', null);
+if ($isFromTestCases == '1') {
+    config(['database.connections.mysql' => $testDBConfig]);
+}
+```
+
+**Why it's bad**:
+- This middleware runs on **every single API request**
+- Any client can add `?from_test_case=1` to any API URL
+- This switches the entire application to the test database for that request
+- In production, this means:
+  - An attacker can read test data (which may contain test credentials, admin accounts, etc.)
+  - An attacker can write to the test database while the app thinks it's in production mode
+  - If the test database has weaker security (no row-level restrictions, admin-level access), this bypasses all production safeguards
+- The loose comparison `== '1'` (not `===`) makes it even easier to trigger accidentally
+
+**How to fix**: Remove this code entirely from the middleware. Test database switching should only happen in the test environment via `phpunit.xml` configuration.
+
+---
+
+### Issue 4.2: Master Password Override for Any User Account
+
+**File**: `app/Models/User.php`
+**Line**: 210
+
+**The actual code** (inside `validateForPassportPasswordGrant()`):
+```php
+if ($password == env('PASSPORT_MASTER_PASSWORD')) {
+    return true;
+}
+```
+
+**Why it's bad**:
+- If `PASSPORT_MASTER_PASSWORD` is set in the production `.env` file, anyone who knows this password can log in as **any user** on the platform — including admins
+- Uses loose comparison `==` instead of `===`
+- Uses `env()` directly instead of `config()` (will return `null` when config is cached, which could cause `$password == null` to be true if password is empty)
+- There's no audit trail when the master password is used — no way to detect if someone is using it
+
+**How to fix**:
+- Ensure `PASSPORT_MASTER_PASSWORD` is never set in production `.env`
+- Add an environment check: `if (app()->environment('local', 'testing') && ...)`
+- Log any usage of the master password
+- Use strict comparison `===`
+
+---
+
+### Issue 4.3: Weak XSS Protection
+
+**File**: `app/Http/Middleware/Xss.php`
+**Lines**: 10-18
+
+**The actual code**:
+```php
+public function handle(Request $request, Closure $next)
+{
+    $input = $request->all();
+    array_walk_recursive($input, function (&$input) {
+        $input = strip_tags($input);
+    });
+    $request->merge($input);
+    return $next($request);
+}
+```
+
+**Why it's bad**:
+- `strip_tags()` is one of the weakest forms of XSS protection. It only removes complete HTML tags but fails to handle:
+  - JavaScript in event handlers: `<img onerror="alert('xss')" src=x>` (partial tags may survive)
+  - Malformed HTML: `<scr<script>ipt>alert('xss')</script>`
+  - Data URLs: `javascript:alert('xss')`
+  - HTML entities that decode to malicious content
+- It runs on ALL request inputs, including fields that legitimately contain HTML (like statement `value` fields which contain formatted content). This silently strips valid HTML from user content.
+- The variable name reuse (`$input` used both as outer and inner variable) is confusing and error-prone
+
+**How to fix**: Use a proper HTML sanitizer library (like `HTMLPurifier`) for fields that allow HTML, and `htmlspecialchars()` or Laravel's `e()` helper for fields that should be plain text. Apply different sanitization rules based on the field, not a blanket `strip_tags()` on everything.
+
+---
+
+### Issue 4.4: Mass Assignment Vulnerability in Tree Model
+
+**File**: `app/Models/Tree.php`
+**Line**: 12
+
+```php
+protected $guarded = [];
+```
+
+**Why it's bad**: Setting `$guarded` to an empty array means every attribute on this model can be mass-assigned. If any controller passes unfiltered request data to `Tree::create($request->all())`, an attacker could set any field — including fields like `user_id`, `admin`, or other sensitive attributes.
+
+**How to fix**: Define either `$fillable` (whitelist of allowed fields) or `$guarded` (blacklist of protected fields) explicitly.
+
+---
+
+## 5. High: N+1 Query Problems (Performance)
+
+### What is the N+1 Query Problem?
+
+When code runs a database query inside a loop, it executes 1 query to fetch the list + N queries (one per item). With 20 items per page, that's 21+ queries instead of 2. With 5 queries per loop iteration, it's 101+ queries.
+
+**Real-world impact**: Slow API responses (2-10 seconds instead of 200ms), high database load, poor user experience, and increased infrastructure costs.
+
+### Issue 5.1: TopicController::hotTopic() — ~7 Queries Per Topic
+
+**File**: `app/Http/Controllers/TopicController.php`
+**Lines**: 2078-2114
+
+This is the code that runs **inside a `foreach` loop** for every topic on the hot topics page:
+
+```php
+foreach ($topics as $topic) {
+    $filter['topicNum'] = $topic->topic_num;
+    $filter['campNum'] = $topic->camp_num ?? 1;
+
+    $liveCamp = Camp::getLiveCamp($filter);                    // ← QUERY 1: Fetch live camp
+    $liveTopic = Topic::getLiveTopic($topic->topic_num, ...);  // ← QUERY 2: Fetch live topic
+
+    $supporterData = Support::getAllSupporterNicknames(         // ← QUERY 3: Fetch supporter nicknames
+        $liveTopic->topic_num, null, $supporterLimit
+    )->each(function ($supporter) {
+        $supporter->first_name = $supporter->first_name[0] ?? '';
+        // ...
+    });
+
+    $topic->topicTags = $liveTopic->tags->makeHidden(['pivot']); // ← QUERY 4: Fetch tags (if not eager loaded)
+    $topic->views = $topic->totalViews();                          // ← QUERY 5: Fetch views count
+
+    $topic->total_supporters_count = count($supporterData) < 5
+        ? 0
+        : count(Support::getAllSupporterOfTopic($liveTopic->topic_num)) - 5;  // ← QUERY 6: DUPLICATE query!
+
+    $getLiveStatement = Statement::getLiveStatement([...]);         // ← QUERY 7: Fetch live statement
+}
+```
+
+**Impact calculation**:
+- Default pagination: 15 topics per page
+- Queries per topic: ~7
+- **Total: ~105 database queries per single API call**
+- This is cached (10 min TTL), but the first request after cache expiry pays the full cost
+
+**Additionally**: `Support::getAllSupporterOfTopic()` on line 2105 is called just to count supporters, but `$supporterData` from line 2088 already has this data. The same query runs twice with identical parameters.
+
+**This exact same pattern is duplicated in:**
+- `featuredTopic()` (lines 2229-2258) — identical code, ~7 queries per topic
+- `preferredTopic()` (lines 2378-2417) — identical pattern in a `->map()` closure
+
+---
+
+### Issue 5.2: ThreadsController::updateThreadsInfo() — 5 Queries Per Thread
+
+**File**: `app/Http/Controllers/ThreadsController.php`
+**Lines**: 409-443
+
+```php
+private function updateThreadsInfo($threads)
+{
+    if(isset($threads)){
+        foreach ($threads->items as $thread) {
+            // QUERY 1: Count posts for this thread
+            $postCount = Reply::where('c_thread_id', $thread->id)
+                ->where('post.is_delete', 0)
+                ->count();
+
+            // QUERY 2: Get namespace ID (uses ->get() instead of ->first(), then loops through results!)
+            $namspaceId = Topic::select('namespace_id')
+                ->where('topic_num', $thread->topic_id)
+                ->get();
+            foreach ($namspaceId as $nId) {
+                $thread->namespace_id = $nId->namespace_id;
+            }
+
+            $thread->post_count = $postCount;
+
+            if ($postCount > 0) {
+                // QUERY 3: Get latest post (almost same query as QUERY 1, but fetches full record)
+                $latestPost = Reply::where('c_thread_id', $thread->id)
+                    ->where('post.is_delete', 0)
+                    ->orderBy('post.updated_at', 'DESC')
+                    ->first();
+
+                // QUERY 4: Get nickname for latest poster
+                $nickName = Nickname::find($latestPost->user_id);
+                if (!empty($nickName)) {
+                    $thread->nick_name = $nickName->nick_name;
+                }
+            }
+        }
+    }
+}
+```
+
+**Why it's bad**:
+- **Query 1 and Query 3** are almost identical — both query `Reply` for the same thread. Query 1 counts, Query 3 fetches the latest. This could be a single query: `$latestPost = Reply::where(...)->latest('updated_at')->first()` and then `$postCount = Reply::where(...)->count()` or use `withCount()`.
+- **Query 2** uses `->get()` (returns a Collection) when it should use `->value('namespace_id')` or `->first()`. Then it loops through the result to assign a single value — this is nonsensical.
+- **Query 4** runs `Nickname::find()` for every thread that has posts
+
+**Impact**: With 20 threads per page × 4-5 queries per thread = **80-100 queries per page load**
+
+**How to fix**:
+- Use `withCount('replies')` on the initial thread query
+- Eager load the latest reply with `with(['latestReply.owner'])`
+- Load topic namespace in the initial query via a join
+
+---
+
+### Issue 5.3: ReplyController::postList() — Repeated Static Call in Loop
+
+**File**: `app/Http/Controllers/ReplyController.php`
+**Lines**: 290-301
+
+```php
+foreach ($response->items as $value) {
+    $allNicname = Nickname::personNicknameArray();  // ← QUERY: Called for EVERY post!
+    // ...
+    $namspaceId = Topic::select('namespace_id')
+        ->where('topic_num', $value->topic_id)
+        ->get();                                     // ← QUERY: Called for EVERY post!
+    foreach($namspaceId as $nId){
+        $thread->namespace_id = $nId->namespace_id;
+    }
+}
+```
+
+**Why it's bad**:
+- `Nickname::personNicknameArray()` returns the current user's nickname IDs. This data is **identical for every iteration** — it should be called once before the loop.
+- The `Topic::select('namespace_id')` query runs for every post, but all posts on the same page share the same topic. Should be queried once.
+
+---
+
+### Issue 5.4: Statement::filterStatementHistory() — 5 Queries Per History Item
+
+**File**: `app/Models/Statement.php`
+**Lines**: 204-271
+
+```php
+foreach ($data->items as $val) {
+    Nickname::getUserIDByNickNameId(...)         // QUERY 1 per item
+    Support::getTotalSupporterByTimestamp(...)    // QUERY 2 per item
+    ChangeAgreeLog::where(...)                   // QUERY 3 per item
+    Nickname::personNicknameArray()              // QUERY 4 per item (same result every time!)
+    Support::ifIamSupporterForChange(...)        // QUERY 5 per item
+}
+```
+
+Same pattern found in `Topic::filterTopicHistory()` and `Camp::filterCampHistory()`.
+
+---
+
+### Issue 5.5: Nickname::topicNicknameUsed() — 8 Sequential Queries in Worst Case
+
+**File**: `app/Models/Nickname.php`
+**Lines**: 170-212
+
+This method uses 8 levels of nested if-else, each executing a database query. In the worst case (when the nickname was used in a reply), ALL 8 queries execute sequentially:
+
+1. Query `Support` table
+2. If no result → Query `Camp` table
+3. If no result → Query `Statement` table
+4. If no result → Query `Topic` table
+5. If no result → Query `NewsFeed` table
+6. If no result → Query `Thread` table
+7. If no result → Query `Reply` table (first fetches all thread IDs, then queries replies)
+8. Final → Query `Nickname` table
+
+**How to fix**: Combine into a single query using UNION or subqueries.
+
+---
+
+### Issue 5.6: Nickname::getSupportCampList() — N+1 Inside Raw SQL Results
+
+**File**: `app/Models/Nickname.php`
+**Lines**: 312-340
+
+After executing the large raw SQL query, the results are looped and for each result:
+```php
+foreach ($results as $rs) {
+    $livecamp = Camp::getLiveCamp($filter);              // QUERY per result
+    $topicLive = Topic::getLiveTopic($topic_num, ...);   // QUERY per result
+    // ... and in some code paths, Topic::getLiveTopic() is called AGAIN (line 328)
+}
+```
+
+---
+
+### Issue 5.7: Support.php — Multiple Methods with Queries in Loops
+
+**File**: `app/Models/Support.php`
+
+| Method | Lines | Problem |
+|--------|-------|---------|
+| `getAllDirectSupporters()` | 75-99 | Calls `getDirectSupporter()` in a loop for each child camp |
+| `getAllSupporters()` | 324-356 | Double loop — queries per camp, then queries again per child camp |
+| `ifIamSingleSupporter()` | 450-461 | Queries database for each camp in `$allChildren` array |
+| `reOrderSupport()` | 689-710 | Calls `update()` on each support record individually instead of batch update |
+
+---
+
+### Issue 5.8: Camp::getSubscriptionList() — N+1 in Loop
+
+**File**: `app/Models/Camp.php`
+**Lines**: 520-550
+
+```php
+foreach ($subscriptions as $sub) {
+    Camp::getLiveCamp(...)    // QUERY per subscription
+    Topic::getLiveTopic(...)  // QUERY per subscription
+}
+```
+
+---
+
+### Issue 5.9: CampController::getSiblingCamps() — 3 Queries Per Camp
+
+**File**: `app/Http/Controllers/CampController.php`
+**Lines**: 1605-1626
+
+```php
+foreach ($siblingCamps as $camp) {
+    Support::getAllSupporterOfTopic(...)   // QUERY per camp
+    Statement::getLiveStatement($filter)   // QUERY per camp
+    Helpers::getCampViewsByDate(...)       // QUERY per camp
+}
+```
+
+---
+
+### Full N+1 Impact Summary
+
+| Endpoint | File | Queries Per Item | Items Per Page | Total Queries Per Request |
+|----------|------|-----------------|----------------|--------------------------|
+| Hot Topics | TopicController.php | ~7 | 15 | **~105** |
+| Featured Topics | TopicController.php | ~7 | 15 | **~105** |
+| Preferred Topics | TopicController.php | ~7 | 15 | **~105** |
+| Thread List | ThreadsController.php | ~5 | 20 | **~100** |
+| Post List | ReplyController.php | ~2 | 20 | **~40** |
+| Topic History | Topic.php | ~5 | 10 | **~50** |
+| Statement History | Statement.php | ~5 | 10 | **~50** |
+| Camp History | Camp.php | ~2 | 10 | **~20** |
+| Sibling Camps | CampController.php | ~3 | variable | **~30+** |
+| Support Camp List | Nickname.php | ~2 | variable | **~20+** |
+
+---
+
+## 6. High: ElasticSearch Inefficiencies
+
+### Issue 6.1: New Client Instance Created on Every Call
+
+**File**: `app/Helpers/ElasticSearch.php`
+**Lines**: 49, 89
+
+```php
+public static function ingestData(...) {
+    $elasticsearch = (new Elasticsearch())->elasticsearchClient;  // Line 49 — NEW connection every time
+    // ...
+}
+
+public static function deleteData($id) {
+    $elasticsearch = (new Elasticsearch())->elasticsearchClient;  // Line 89 — ANOTHER new connection
+    // ...
+}
+```
+
+**Why it's bad**: Every call to `ingestData()` or `deleteData()` creates a new Elasticsearch client object, which involves establishing a new HTTP connection to the ES server. When a Topic is saved, the boot event triggers ES indexing for both live and review versions — that's 2 new connections. If you save a Topic + Camp + Statement in one request, that's 6 new connections.
+
+**How to fix**: Use a singleton pattern or register the client in Laravel's service container so the same instance is reused.
+
+---
+
+### Issue 6.2: No Timeout Configuration
+
+**File**: `app/Helpers/ElasticSearch.php`
+**Lines**: 19-23
+
+```php
+$clientBuilder = ClientBuilder::create()->setHosts([$host]);
+if (!empty($username)) {
+    $clientBuilder->setBasicAuthentication($username, $password);
+}
+return $this->elasticsearchClient = $clientBuilder->build();
+```
+
+**Why it's bad**: No connection timeout or request timeout is configured. If the ElasticSearch server is down or slow:
+- The HTTP request from a user will hang indefinitely waiting for ES
+- The PHP worker becomes blocked, eventually timing out at the web server level (30-60 seconds)
+- Multiple blocked workers can exhaust the server's worker pool, causing the entire API to become unresponsive
+
+**How to fix**: Add timeouts to the client builder:
+```php
+$clientBuilder->setConnectionParams([
+    'client' => [
+        'connect_timeout' => 3,  // 3 seconds to establish connection
+        'timeout' => 5,          // 5 seconds for the request
+    ]
+]);
+```
+
+---
+
+### Issue 6.3: Synchronous ES Operations in Model boot() Events
+
+**Files**: `app/Models/Topic.php`, `Camp.php`, `Statement.php`, `Nickname.php`, `Support.php`
+
+Every time any of these models is saved, the `saved()` boot event immediately calls `ElasticSearch::ingestData()`, which:
+1. Creates a new ES client (Issue 6.1)
+2. Makes a synchronous HTTP call to ElasticSearch
+3. Waits for ES to respond before the save operation completes
+
+**Why it's bad**:
+- User has to wait for ES to respond on every topic/camp/statement save — adds 100-500ms to every write operation
+- If ES is slow or down, all write operations slow down or fail
+- Multiple models saved in one request (e.g., creating a topic creates Topic + Camp + Support) means 3+ synchronous ES calls
+
+**How to fix**: Queue the ES indexing as a background job:
+```php
+dispatch(new IndexToElasticSearch($id, $type, $data))->onQueue('elasticsearch');
+```
+
+---
+
+### Issue 6.4: Search Aggregation Bug
+
+**File**: `app/Models/Search.php`
+
+The search query includes:
+```json
+"aggs": { "type_counts": { "terms": { "field": "type" } } }
+```
+
+But the `type` field on the live ES index is mapped as `text` (auto-detected), not `keyword`. Aggregations on `text` fields fail with:
+> "Text fields are not optimised for operations that require per-document field data"
+
+**How to fix**: Change to `type.keyword` in the aggregation, or ensure the bulk import command's index mapping (which correctly defines `type` as `keyword`) is used.
+
+---
+
+### Issue 6.5: Bulk Import Command Crashes on Fresh Index
+
+**File**: `app/Console/Commands/AddExsistingDataToElasticSearch.php`
+**Lines**: 37-41
+
+The `indices()->exists()` check throws a 404 exception in the ES 8.x PHP client instead of returning `false`, which crashes the entire import command on a fresh ES instance.
+
+**How to fix**: Wrap the delete in a try-catch (detailed in our previous discussion).
+
+---
+
+### Issue 6.6: deleteData() Searches Before Deleting
+
+**File**: `app/Helpers/ElasticSearch.php`
+**Lines**: 88-108
+
+```php
+public static function deleteData($id) {
+    $elasticsearch = (new Elasticsearch())->elasticsearchClient;
+    // First SEARCH for the document...
+    $response = $elasticsearch->search($params);
+    // Then check if it exists...
+    if (isset($response['hits']['hits']) && ...) {
+        // Then DELETE it
+        $response = $elasticsearch->delete($delParam);
+    }
+}
+```
+
+**Why it's bad**: This makes **2 HTTP calls** to ES (search + delete) when a single `delete()` call would suffice. If the document doesn't exist, the `delete()` call returns a 404 which can be caught. The search-before-delete pattern doubles the latency and doubles the ES server load.
+
+**How to fix**: Just call `$elasticsearch->delete($delParam)` directly and catch the 404 if the document doesn't exist.
+
+---
+
+## 7. High: env() Usage Outside Config Files
+
+### What's the Problem?
+
+In Laravel, `env()` reads from the `.env` file. When you run `php artisan config:cache` in production (which you should), Laravel caches all config files and `env()` stops reading from `.env` — it returns `null` for everything. The only place `env()` should be called is inside `config/*.php` files, and the rest of the code should use `config('key')`.
+
+### All Instances Found
+
+| File | Line(s) | Code | Impact If Config Cached |
+|------|---------|------|------------------------|
+| `app/Helpers/ElasticSearch.php` | 16 | `env('ELASTICSEARCH_HOSTS', 'localhost:9200')` | ES client connects to `localhost:9200` instead of the actual server |
+| `app/Helpers/ElasticSearch.php` | 17 | `env('ELASTICSEARCH_BASIC_AUTH_USERNAME', null)` | Auth credentials become `null` — ES auth fails |
+| `app/Helpers/ElasticSearch.php` | 18 | `env('ELASTICSEARCH_BASIC_AUTH_PASSWORD', null)` | Same |
+| `app/Http/Middleware/CorsMiddleware.php` | 19 | `env('ACCESS_CONTROL_ALLOW_ORIGIN')` | CORS origins become `null` — `explode(null)` produces empty array, all origins rejected |
+| `app/Http/Middleware/CheckClientCredentialsMiddleware.php` | 33 | `env('PASSPORT_BYPASS_CLIENT_CREDENTIALS')` | Bypass flag becomes `null` — no functional impact (bypass disabled) |
+| `app/Models/User.php` | 210 | `env('PASSPORT_MASTER_PASSWORD')` | Master password becomes `null` — any empty password matches `null == null` → **security vulnerability** |
+
+**How to fix**:
+1. Create `config/elasticsearch.php` with `'hosts' => env('ELASTICSEARCH_HOSTS', 'localhost:9200')` etc.
+2. Create `config/cors.php` (or add to existing config) with `'allowed_origins' => env('ACCESS_CONTROL_ALLOW_ORIGIN')`
+3. Use `config('elasticsearch.hosts')` in the code instead of `env()`
+4. Critical: The User.php `env()` call for master password is particularly dangerous because `env()` returning `null` means `$password == null` could be true for empty strings
+
+---
+
+## 8. Medium: Inefficient Code Patterns
+
+### Issue 8.1: Inefficient unset() in Loops
+
+Instead of filtering arrays with `array_filter()`, the code loops through arrays and calls `unset()` on matching elements. This is slower and harder to read.
+
+**Found in 4 files, 6 locations:**
+
+| File | Lines | What It Does |
+|------|-------|-------------|
+| `TopicController.php` | 596, 602 | Removes items from `$archiveCampSupportNicknames` array |
+| `TopicController.php` | 1289, 1294 | Same pattern repeated in different method |
+| `CampController.php` | 478 | Removes items from `$result` array |
+| `ProfileController.php` | 559, 706, 711 | Removes private fields from user data |
+
+---
+
+### Issue 8.2: updateOrCreate() Inside Loop
+
+**File**: `app/Http/Controllers/ProfileController.php`
+**Lines**: 230-234
+
+```php
+foreach ($userTags as $tagId) {
+    UserTag::updateOrCreate(
+        ['user_id' => $user->id, 'tag_id' => $tagId],
+    );
+}
+```
+
+**Why it's bad**: Each iteration runs 1-2 database queries (SELECT to check existence + INSERT or UPDATE). With 10 tags, that's 10-20 queries. Laravel's `upsert()` can do this in a single query.
+
+---
+
+### Issue 8.3: Duplicate Method Calls in Same Loop
+
+**File**: `app/Http/Controllers/TopicController.php`
+
+`Support::getAllSupporterOfTopic()` is called **twice** with identical parameters in the same loop iteration:
+
+- `hotTopic()`: Lines 2088 (to get supporter data) and 2105 (to count them)
+- `featuredTopic()`: Lines 2241 and 2257
+
+The first call returns the data. The second call re-runs the entire query just to `count()` the result. Should call once and reuse.
+
+---
+
+### Issue 8.4: personNicknameArray() Called Inside Loops
+
+`Nickname::personNicknameArray()` returns the current authenticated user's nickname IDs. This data is identical for every iteration — it should be called once before the loop and stored in a variable.
+
+| File | Lines |
+|------|-------|
+| `ReplyController.php` | 292 (inside postList loop) |
+| `TopicController.php` | 338 (inside filterTopicHistory loop) |
+| `Statement.php` | 237 (inside filterStatementHistory loop) |
+
+---
+
+### Issue 8.5: Unnecessary Collection-to-Array Conversions
+
+**File**: `app/Http/Controllers/SupportController.php`
+**Lines**: 800-810
+
+Three consecutive queries all end with `->get()->toArray()`:
+```php
+$archiveDirectSupporters = Nickname::select(...)->whereIn(...)->get()->toArray();
+$archiveExplicitSupporters = Nickname::select(...)->whereIn(...)->get()->toArray();
+$revokableSupporters = Nickname::select(...)->whereIn(...)->get()->toArray();
+```
+
+Converting to array loses all Collection methods (filtering, mapping, etc.) and forces raw array operations. Unless the downstream code specifically requires arrays, keep as Collections.
+
+---
+
+### Issue 8.6: Duplicated Raw SQL (Copy-Paste)
+
+**File**: `app/Models/Nickname.php`
+
+`getSupportCampList()` (lines 298-308) and `getNicknameSupportedCampList()` (lines 396-407) contain nearly identical 100+ character raw SQL queries with 5 nested subqueries. The only difference is the `ORDER BY` clause. This is unmaintainable — a bug fix in one must be replicated in the other.
+
+**Same issue in Support.php**: `getSupportedCampsList()` (lines 490-555) contains a 60-line raw SQL query that partially overlaps with queries in Nickname.php.
+
+---
+
+### Issue 8.7: Artisan Commands Executed in HTTP Routes
+
+**File**: `routes/api.php`
+**Lines**: 239-261
+
+```php
+Route::get('/all', function () {
+    \Illuminate\Support\Facades\Artisan::call('tree:all');
+    return response()->json(['message' => 'All topic trees generated successfully.']);
+});
+```
+
+**Why it's bad**: `tree:all` is a long-running command that generates all topic trees. Running it in an HTTP request context means:
+- The request will likely timeout (30-60 seconds)
+- The web worker is blocked for the entire duration
+- No progress feedback to the caller
+- If the connection drops, the work may be interrupted
+
+**How to fix**: Queue it as a background job and return immediately with a job ID.
+
+---
+
+### Issue 8.8: ProfileController — Transaction Without Begin
+
+**File**: `app/Http/Controllers/ProfileController.php`
+**Lines**: 242-246
+
+`DB::commit()` is called without a preceding `DB::beginTransaction()`. This is either a bug (transaction was never started) or the begin transaction is in a different code path that may not always execute.
+
+---
+
+## 9. Medium: Missing Error Handling
+
+### Issue 9.1: Null Access on Model Results
+
+Three models call `Topic::getLiveTopic()` and immediately access properties on the result without checking if it returned `null`:
+
+| File | Lines | Code |
+|------|-------|------|
+| `Topic.php` | 85-89 | `$liveTopic = Topic::getLiveTopic(...)` then `$liveTopic->namespace_id` |
+| `Camp.php` | 62-63 | Same pattern |
+| `Statement.php` | 38-48 | Same pattern |
+
+**Why it's bad**: If `getLiveTopic()` returns `null` (e.g., topic doesn't exist or hasn't gone live), accessing `->namespace_id` throws `ErrorException: Attempt to read property on null`, crashing the request.
+
+---
+
+### Issue 9.2: ActivityLoggerJob — No Try-Catch
+
+**File**: `app/Jobs/ActivityLoggerJob.php`
+**Lines**: 32-64
+
+The entire job logic has no try-catch wrapping. If any database query or model relationship fails, the job fails silently. Since this runs on a queue, the failure may not be noticed for days.
+
+---
+
+### Issue 9.3: External API Without Timeout
+
+**File**: `app/Http/Controllers/UserController.php`
+**Lines**: 2001-2046
+
+Gravatar image fetching uses `curl_exec()` without setting `CURLOPT_TIMEOUT` or `CURLOPT_CONNECTTIMEOUT`. If the Gravatar server is slow or unresponsive, the entire API request hangs indefinitely.
+
+---
+
+## 10. Medium: Middleware Issues
+
+### Issue 10.1: strpos() Without Strict Comparison
+
+**File**: `app/Http/Middleware/CorsMiddleware.php`
+**Line**: 60
+
+```php
+if (strpos($request->url(), 'api/v3')) {
+```
+
+`strpos()` returns `0` (which is falsy) if the match is at position 0. This means if the URL starts with `api/v3`, the condition evaluates to `false` and CORS headers are not set. Should use `strpos(...) !== false` or `str_contains()` (PHP 8+) or `$request->is('api/v3*')`.
+
+---
+
+### Issue 10.2: Loose Comparison for Critical Status Checks
+
+**File**: `app/Http/Middleware/CheckStatus.php`
+**Lines**: 36, 47
+
+```php
+if ($user->status != 1) {       // Line 36
+if ($user->is_active != 1) {    // Line 47
+```
+
+Using `!=` (loose comparison) instead of `!==` (strict). If the database returns a string `"1"` or `true`, the comparison works. But if it returns `null` or `false`, the loose comparison may produce unexpected results.
+
+---
+
+### Issue 10.3: CorsMiddleware — Variable Typo and instanceof Misuse
+
+**File**: `app/Http/Middleware/CorsMiddleware.php`
+**Line**: 27, 51
+
+```php
+$SymfonyResopnse = 'Symfony\Component\HttpFoundation\Response';  // Line 27 — "Resopnse" typo
+// ...
+if($response instanceof $SymfonyResopnse) {  // Line 51 — instanceof with string variable
+```
+
+Two problems:
+1. Typo in variable name: `Resopnse` instead of `Response`
+2. Using `instanceof` with a string variable is unreliable in PHP. It should use the class directly: `if ($response instanceof \Symfony\Component\HttpFoundation\Response)`
+
+---
+
+### Issue 10.4: SetLanguage — No Locale Validation
+
+**File**: `app/Http/Middleware/SetLanguage.php`
+**Lines**: 19-22
+
+```php
+$acceptLanguage = $request->header('accept-language');
+if ($acceptLanguage) {
+    $language = current(explode(',', $acceptLanguage));
+    app('translator')->setLocale($language);
+}
+```
+
+**Why it's bad**: The `Accept-Language` header contains values like `en-US,en;q=0.9,fr;q=0.8`. The code takes the first segment (`en-US,en;q=0.9` split by `,` → `en-US`) without:
+- Stripping quality values (`;q=0.9`)
+- Normalizing to base language (`en-US` → `en`)
+- Validating against supported locales
+- Falling back gracefully if the locale is not supported
+
+This could set the locale to `en-US;q=0.9` which is not a valid locale string.
+
+---
+
+### Issue 10.5: $_REQUEST Access in Nickname Model
+
+**File**: `app/Models/Nickname.php`
+**Line**: 283
+
+```php
+$namespace = isset($_REQUEST['namespace']) ? $_REQUEST['namespace'] : $namespace;
+```
+
+**Why it's bad**: Accessing PHP's superglobal `$_REQUEST` directly bypasses Laravel's request handling, input sanitization, and middleware. It also makes the code untestable (tests can't easily mock `$_REQUEST`). Should use the Request object passed through the controller.
+
+---
+
+## 11. Low: Code Quality & Anti-Patterns
+
+### Issue 11.1: Dead Code
+
+| File | Lines | Issue |
+|------|-------|-------|
+| `app/Models/Statement.php` | 269 | `$val->parsed_value = $val->parsed_value;` — self-assignment, does nothing |
+| `app/Http/Middleware/SetLanguage.php` | 26 | `app('translator')->getLocale();` — called but return value not used |
+| `app/Http/Controllers/SearchController.php` | 84 | `$search_ids=[]` initialized but never populated |
+| `app/Http/Middleware/ExampleMiddleware.php` | entire file | Unused placeholder file |
+
+---
+
+### Issue 11.2: Typos and Inconsistent Naming
+
+| File | Location | Issue |
+|------|----------|-------|
+| `ReplyController.php` | Line 292 | Variable `$allNicname` — should be `$allNicknames` |
+| `ValidationRules.php` | Method name | `getUpdateProfileValidatonRules()` — typo "Validaton" should be "Validation" |
+| `ValidationRules.php` | Method name | `getfacebookDeleteDataCallBackValidationRules()` — inconsistent casing (lowercase `f`, `CallBack` mixed) |
+| `CorsMiddleware.php` | Line 27 | `$SymfonyResopnse` — typo "Resopnse" should be "Response" |
+| `ThreadsController.php` | Line 417 | `$namspaceId` — should be `$namespaceId` |
+
+---
+
+### Issue 11.3: Hardcoded Magic Numbers
+
+| File | Lines | Value | Should Be |
+|------|-------|-------|-----------|
+| `TopicController.php` | 2063, 2225 | `600` (cache TTL in seconds) | `config('cache.topics_ttl', 600)` |
+| `CorsMiddleware.php` | 24 | `'https://canonizer3.canonizer.com'` | `config('cors.fallback_origin')` |
+| `AddExsistingDataToElasticSearch.php` | 119 | `250` (batch size) | `config('elasticsearch.batch_size', 250)` |
+| `AddExsistingDataToElasticSearch.php` | 202 | `3` (max retries) | `config('elasticsearch.max_retries', 3)` |
+
+---
+
+### Issue 11.4: Reply.php — Potential Broken Relationship
+
+**File**: `app/Models/Reply.php`
+**Line**: 67
+
+The `owner()` relationship may reference `'App\Model\Nickname'` (singular `Model`) instead of `'App\Models\Nickname'` (plural `Models`). This would cause a `Class not found` error when loading the relationship.
+
+---
+
+### Issue 11.5: NicknameController — save() vs update()
+
+**File**: `app/Http/Controllers/NicknameController.php`
+**Line**: 213
+
+```php
+$nickname->private = $request->visibility_status;
+$nickname->update();
+```
+
+Calling `->update()` without parameters on an Eloquent model doesn't persist dirty attributes the way `->save()` does. This should be `->save()` instead.
+
+---
+
+### Issue 11.6: Missing Return Type Declarations
+
+**File**: `app/Http/Request/Validate.php`
+
+The `validate()` method has no return type hint, making it unclear whether it returns an error object or null on success.
+
+---
+
+## 12. Full Issue Summary Table
+
+| # | Severity | Category | File | Issue |
+|---|----------|----------|------|-------|
+| 1 | Critical | SQL Injection | Nickname.php:280-308 | 6 injection points in getSupportCampList() raw SQL |
+| 2 | Critical | SQL Injection | Nickname.php:373-407 | Duplicated SQL injection in getNicknameSupportedCampList() |
+| 3 | Critical | SQL Injection | Support.php:490-555 | $topicNum and $user_id in 60-line raw SQL |
+| 4 | Critical | SQL Injection | Camp.php:349 | whereRaw with concatenated $topicNum |
+| 5 | Critical | SQL Injection | Camp.php:365 | whereRaw with concatenated $topicNum and $campNum |
+| 6 | Critical | SQL Injection | Camp.php:699 | Same pattern repeated |
+| 7 | Critical | SQL Injection | Camp.php:998 | Same pattern repeated |
+| 8 | Critical | SQL Injection | Topic.php:382 | whereRaw with concatenated time() |
+| 9 | Critical | SQL Injection | Search.php:202,215,262 | implode() in raw SQL without parameterization |
+| 10 | Critical | Security | CorsMiddleware.php:41-47 | Database switching via ?from_test_case=1 |
+| 11 | Critical | Security | User.php:210 | Master password override for any account |
+| 12 | Critical | Security | Xss.php:12-16 | strip_tags() insufficient for XSS protection |
+| 13 | Critical | Security | Tree.php:12 | $guarded=[] allows mass assignment |
+| 14 | Critical | Security | Nickname.php:283 | Direct $_REQUEST access bypasses Laravel |
+| 15 | High | N+1 Query | TopicController.php:2078-2114 | ~7 queries per topic in hotTopic() loop |
+| 16 | High | N+1 Query | TopicController.php:2229-2258 | Same in featuredTopic() (duplicated code) |
+| 17 | High | N+1 Query | TopicController.php:2378-2417 | Same in preferredTopic() |
+| 18 | High | N+1 Query | TopicController.php:299-341 | ~5 queries per item in filterTopicHistory() |
+| 19 | High | N+1 Query | ThreadsController.php:411-443 | ~5 queries per thread in updateThreadsInfo() |
+| 20 | High | N+1 Query | ReplyController.php:290-301 | Repeated queries in postList() loop |
+| 21 | High | N+1 Query | CampController.php:1605-1626 | 3 queries per camp in getSiblingCamps() |
+| 22 | High | N+1 Query | SupportController.php:514-520 | Camp::getLiveCamp() per support record |
+| 23 | High | N+1 Query | Statement.php:204-271 | 5 queries per item in filterStatementHistory() |
+| 24 | High | N+1 Query | Camp.php:520-550 | 2 queries per sub in getSubscriptionList() |
+| 25 | High | N+1 Query | Camp.php:753-761 | 2 queries per item in filterCampHistory() |
+| 26 | High | N+1 Query | Support.php:75-99 | Query per child camp in getAllDirectSupporters() |
+| 27 | High | N+1 Query | Support.php:324-356 | Double loop with queries in getAllSupporters() |
+| 28 | High | N+1 Query | Support.php:450-461 | Query per child camp in ifIamSingleSupporter() |
+| 29 | High | N+1 Query | Support.php:689-710 | update() per record in reOrderSupport() |
+| 30 | High | N+1 Query | Nickname.php:170-212 | 8 sequential queries in topicNicknameUsed() |
+| 31 | High | N+1 Query | Nickname.php:312-340 | 2 queries per result in getSupportCampList() |
+| 32 | High | ElasticSearch | ElasticSearch.php:49,89 | New client instance on every call |
+| 33 | High | ElasticSearch | ElasticSearch.php:19-23 | No timeout configuration |
+| 34 | High | ElasticSearch | 5 model boot() events | Synchronous ES calls block every save |
+| 35 | High | ElasticSearch | Search.php | Aggregation on text field fails |
+| 36 | High | ElasticSearch | AddExsistingDataToElasticSearch.php:37-41 | Import crashes on missing index |
+| 37 | High | ElasticSearch | ElasticSearch.php:88-108 | Unnecessary search-before-delete (2 calls instead of 1) |
+| 38 | High | env() Misuse | ElasticSearch.php:16-18 | 3 env() calls — returns null when config cached |
+| 39 | High | env() Misuse | CorsMiddleware.php:19 | env() for CORS origins |
+| 40 | High | env() Misuse | CheckClientCredentialsMiddleware.php:33 | env() for passport bypass |
+| 41 | High | env() Misuse | User.php:210 | env() for master password (dangerous with cache) |
+| 42 | Medium | Inefficient | TopicController.php:596,602,1289,1294 | unset() in loops instead of array_filter() |
+| 43 | Medium | Inefficient | CampController.php:478 | unset() in loop |
+| 44 | Medium | Inefficient | ProfileController.php:559,706,711 | unset() in loop |
+| 45 | Medium | Inefficient | ProfileController.php:230-234 | updateOrCreate() in loop instead of upsert() |
+| 46 | Medium | Inefficient | TopicController.php:2088+2105 | Duplicate Support query in same loop |
+| 47 | Medium | Inefficient | TopicController.php:2241+2257 | Same duplicate in featuredTopic() |
+| 48 | Medium | Inefficient | 3 files | personNicknameArray() called in loop |
+| 49 | Medium | Inefficient | SupportController.php:800-810 | Unnecessary ->toArray() conversions |
+| 50 | Medium | Inefficient | Nickname.php:298+396 | 100-line raw SQL duplicated between 2 methods |
+| 51 | Medium | Inefficient | routes/api.php:239-261 | Artisan commands in HTTP routes |
+| 52 | Medium | Inefficient | ProfileController.php:242-246 | DB::commit() without DB::beginTransaction() |
+| 53 | Medium | Error Handling | Topic.php:85-89 | Null access on getLiveTopic() result |
+| 54 | Medium | Error Handling | Camp.php:62-63 | Same |
+| 55 | Medium | Error Handling | Statement.php:38-48 | Same |
+| 56 | Medium | Error Handling | ActivityLoggerJob.php:32-64 | No try-catch in queue job |
+| 57 | Medium | Error Handling | UserController.php:2001-2046 | curl without timeout |
+| 58 | Medium | Middleware | CorsMiddleware.php:60 | strpos() without strict comparison |
+| 59 | Medium | Middleware | CheckStatus.php:36,47 | Loose != instead of !== |
+| 60 | Medium | Middleware | CorsMiddleware.php:27,51 | Typo + instanceof with string |
+| 61 | Medium | Middleware | SetLanguage.php:19-22 | No locale validation |
+| 62 | Medium | Middleware | CorsMiddleware.php:19 | Null check missing before explode() |
+| 63 | Low | Dead Code | Statement.php:269 | Self-assignment does nothing |
+| 64 | Low | Dead Code | SetLanguage.php:26 | getLocale() result unused |
+| 65 | Low | Dead Code | SearchController.php:84 | $search_ids never populated |
+| 66 | Low | Dead Code | ExampleMiddleware.php | Entire unused file |
+| 67 | Low | Naming | ReplyController.php:292 | $allNicname typo |
+| 68 | Low | Naming | ValidationRules.php | getUpdateProfileValidatonRules typo |
+| 69 | Low | Naming | ValidationRules.php | getfacebookDeleteDataCallBackValidationRules casing |
+| 70 | Low | Naming | CorsMiddleware.php:27 | $SymfonyResopnse typo |
+| 71 | Low | Naming | ThreadsController.php:417 | $namspaceId typo |
+| 72 | Low | Hardcoded | TopicController.php:2063,2225 | Cache TTL 600 |
+| 73 | Low | Hardcoded | CorsMiddleware.php:24 | Fallback origin URL |
+| 74 | Low | Bug | Reply.php:67 | Possibly wrong class path in relationship |
+| 75 | Low | Bug | NicknameController.php:213 | update() vs save() |
+| 76 | Low | Quality | Validate.php | Missing return type declarations |
+
+---
+
+## 13. Recommended Fix Priority & Timeline
+
+### Phase 1: Immediate — Security (Days 1-3)
+
+| # | Action | Files | Estimated Effort |
+|---|--------|-------|-----------------|
+| 1 | **Fix all SQL injection vulnerabilities** — Replace string concatenation with parameterized queries in Camp.php, Nickname.php, Support.php, Topic.php, Search.php | 5 files | 4-6 hours |
+| 2 | **Remove database switching** — Delete the `from_test_case` logic in CorsMiddleware.php | 1 file | 15 minutes |
+| 3 | **Secure master password** — Add environment check (`local`/`testing` only) in User.php | 1 file | 15 minutes |
+| 4 | **Remove $_REQUEST access** — Replace with proper Request parameter in Nickname.php | 1 file | 15 minutes |
+
+### Phase 2: Week 1 — Performance (Most Impactful)
+
+| # | Action | Files | Estimated Effort |
+|---|--------|-------|-----------------|
+| 5 | **Fix hotTopic/featuredTopic/preferredTopic N+1** — Batch load camps, topics, supporters, statements before the loop. Store result of duplicate calls. | TopicController.php | 4-6 hours |
+| 6 | **Fix threadList N+1** — Use withCount, eager loading, single query for post count + latest post | ThreadsController.php | 2-3 hours |
+| 7 | **Fix postList N+1** — Call personNicknameArray() once before loop, preload namespace | ReplyController.php | 1 hour |
+| 8 | **Fix filterTopicHistory / filterStatementHistory / filterCampHistory N+1** — Batch load nicknames, supporter counts, change agree logs before loop | Topic.php, Statement.php, Camp.php | 3-4 hours |
+| 9 | **Queue ElasticSearch indexing** — Move from synchronous boot() events to queued jobs | 5 model files + new Job class | 2-3 hours |
+| 10 | **Singleton ES client** — Register in service container, add timeouts | ElasticSearch.php, AppServiceProvider | 1 hour |
+
+### Phase 3: Week 2 — Stability & Correctness
+
+| # | Action | Files | Estimated Effort |
+|---|--------|-------|-----------------|
+| 11 | **Move env() calls to config files** — Create config/elasticsearch.php, update CorsMiddleware, CheckClientCredentials, User.php | 4 files + new config | 1-2 hours |
+| 12 | **Add null checks** — Before accessing properties on getLiveTopic() / getLiveCamp() results | Topic.php, Camp.php, Statement.php | 1 hour |
+| 13 | **Add error handling to ActivityLoggerJob** — Wrap in try-catch with logging | ActivityLoggerJob.php | 30 minutes |
+| 14 | **Add timeouts to curl calls** — Set CURLOPT_TIMEOUT in UserController | UserController.php | 15 minutes |
+| 15 | **Fix ES aggregation bug** — Use `type.keyword` instead of `type` | Search.php | 15 minutes |
+| 16 | **Fix ES import command** — Handle missing index gracefully | AddExsistingDataToElasticSearch.php | 15 minutes |
+
+### Phase 4: Week 3 — Code Quality
+
+| # | Action | Files | Estimated Effort |
+|---|--------|-------|-----------------|
+| 17 | **Fix middleware issues** — strpos strict comparison, loose comparisons, typo, locale validation | CorsMiddleware.php, CheckStatus.php, SetLanguage.php | 1 hour |
+| 18 | **Replace unset() loops** — Use array_filter() | TopicController, CampController, ProfileController | 1 hour |
+| 19 | **Replace updateOrCreate loop** — Use upsert() | ProfileController.php | 30 minutes |
+| 20 | **Fix remaining N+1 in models** — Nickname, Support, Camp subscription list | Nickname.php, Support.php, Camp.php | 3-4 hours |
+| 21 | **Remove dead code** — ExampleMiddleware, unused variables, self-assignments | 4 files | 30 minutes |
+| 22 | **Fix typos and naming** — Variable names, method names | 5 files | 30 minutes |
+
+### Total Estimated Effort
+
+| Phase | Timeline | Effort |
+|-------|----------|--------|
+| Phase 1: Security | Days 1-3 | ~5 hours |
+| Phase 2: Performance | Week 1 | ~15 hours |
+| Phase 3: Stability | Week 2 | ~5 hours |
+| Phase 4: Code Quality | Week 3 | ~7 hours |
+| **Total** | **3 weeks** | **~32 hours** |

--- a/docs/openclaw-skill/SKILL.md
+++ b/docs/openclaw-skill/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: canonizer
+description: Interact with Canonizer.com — login, create topics, camps, statements, threads, replies, and manage support via API (curl).
+metadata: { "openclaw": { "emoji": "🏛️" } }
+---
+
+# Canonizer Skill
+
+Canonizer is a consensus-building platform where users create topics, camps (positions), and statements to build structured knowledge. This skill uses curl API calls to interact with Canonizer.
+
+## Configuration
+
+- **Production API**: `https://beta-api3.canonizer.com/api/v3`
+- **Local dev API**: `http://127.0.0.1:8000/api/v3`
+- **Client ID**: `2`
+- **Client Secret**: `x6UX6WOv482Ree7r4sqEdzksvoadWKp6Dmgexbs7`
+
+Use the production API unless the user says "local" or "localhost".
+
+## Step 1: Login
+
+Always login first to get a token. Store it for all subsequent calls.
+
+```bash
+curl -s -X POST "{API_URL}/user/login" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "username": "BOT_EMAIL",
+    "password": "BOT_PASSWORD",
+    "client_id": "2",
+    "client_secret": "x6UX6WOv482Ree7r4sqEdzksvoadWKp6Dmgexbs7"
+  }'
+```
+
+Response: `data.auth.access_token` — use as `Authorization: Bearer TOKEN` in all calls.
+
+## Step 2: Get Nickname ID
+
+Required for all content creation. Call once after login.
+
+```bash
+curl -s "{API_URL}/get-nick-name-list" \
+  -H "Authorization: Bearer TOKEN"
+```
+
+Response: Array of nicknames. Use the first one's `id` as `nick_name` in all creation calls.
+
+## Actions
+
+### Create a Topic
+
+```bash
+curl -s -X POST "{API_URL}/topic/save" \
+  -H "Authorization: Bearer TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "topic_name": "Your Topic Title (max 80 chars)",
+    "namespace": 1,
+    "nick_name": NICK_ID,
+    "note": "Optional note"
+  }'
+```
+
+- `namespace`: Use `1` for "General". Get full list via `GET {API_URL}/get-all-namespaces`
+- Response includes `topic_num` — save it for creating camps/statements
+- An "Agreement" camp (camp_num=1) is auto-created with every topic
+
+### Create a Camp
+
+```bash
+curl -s -X POST "{API_URL}/camp/save" \
+  -H "Authorization: Bearer TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "topic_num": TOPIC_NUM,
+    "camp_name": "Camp Name (max 80 chars)",
+    "parent_camp_num": 1,
+    "nick_name": NICK_ID,
+    "note": "Optional note"
+  }'
+```
+
+- `parent_camp_num`: Use `1` for Agreement (root). For sub-camps, use the parent's camp_num.
+- Response includes `camp_num` — save it for statements
+
+### Create a Statement
+
+```bash
+curl -s -X POST "{API_URL}/store-camp-statement" \
+  -H "Authorization: Bearer TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "topic_num": TOPIC_NUM,
+    "camp_num": CAMP_NUM,
+    "nick_name": NICK_ID,
+    "submitter": NICK_ID,
+    "statement": "<p>Your statement in HTML</p>",
+    "event_type": "create",
+    "note": "Optional edit summary"
+  }'
+```
+
+- `submitter`: Same as `nick_name` (your nickname ID)
+- `event_type`: `"create"` for new, `"update"` for editing existing
+- `statement`: HTML content — use `<p>`, `<h2>`, `<ul>`, `<li>`, `<a>` tags
+- Statements go through a review period before going live
+
+### Create a Forum Thread
+
+```bash
+curl -s -X POST "{API_URL}/thread/save" \
+  -H "Authorization: Bearer TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Thread Title (max 100 chars)",
+    "camp_num": CAMP_NUM,
+    "topic_num": TOPIC_NUM,
+    "topic_name": "Topic Name",
+    "nick_name": NICK_ID
+  }'
+```
+
+- `topic_name`: Required — the name of the topic this thread belongs to
+- Response includes thread `id` — save it for replies
+
+### Reply to a Thread
+
+```bash
+curl -s -X POST "{API_URL}/post/save" \
+  -H "Authorization: Bearer TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "body": "<p>Your reply in HTML</p>",
+    "thread_id": THREAD_ID,
+    "nick_name": NICK_ID,
+    "camp_num": CAMP_NUM,
+    "topic_num": TOPIC_NUM,
+    "topic_name": "Topic Name"
+  }'
+```
+
+### Add Support to a Camp
+
+```bash
+curl -s -X POST "{API_URL}/support/add" \
+  -H "Authorization: Bearer TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "topic_num": TOPIC_NUM,
+    "camp_num": CAMP_NUM,
+    "nick_name": NICK_ID,
+    "add_camp": [{"camp_num": CAMP_NUM, "support_order": 1}]
+  }'
+```
+
+### Search
+
+```bash
+curl -s "{API_URL}/search?term=QUERY&type=TYPE&size=20&page=1"
+```
+
+- `type`: `topic`, `camp`, `statement`, or `nickname`
+- No auth required for search
+
+### Get Topic Details
+
+```bash
+curl -s -X POST "{API_URL}/get-topic-record" \
+  -H "Content-Type: application/json" \
+  -d '{"topic_num": TOPIC_NUM, "camp_num": 1}'
+```
+
+### Get Camp Details
+
+```bash
+curl -s -X POST "{API_URL}/get-camp-record" \
+  -H "Content-Type: application/json" \
+  -d '{"topic_num": TOPIC_NUM, "camp_num": CAMP_NUM}'
+```
+
+### Get Camp Statement
+
+```bash
+curl -s -X POST "{API_URL}/get-camp-statement" \
+  -H "Content-Type: application/json" \
+  -d '{"topic_num": TOPIC_NUM, "camp_num": CAMP_NUM, "as_of": "default"}'
+```
+
+### Get Thread List
+
+```bash
+curl -s "{API_URL}/thread/list?topic_num=TOPIC_NUM&camp_num=CAMP_NUM&per_page=10&page=1"
+```
+
+### Get Thread Replies
+
+```bash
+curl -s "{API_URL}/post/list/THREAD_ID"
+```
+
+### Get Namespaces
+
+```bash
+curl -s "{API_URL}/get-all-namespaces"
+```
+
+## Workflow Guidelines
+
+1. **Always login first** and store the token
+2. **Get your nickname ID** — required for all content creation
+3. **Search before creating** — check if a similar topic already exists
+4. **Save IDs** — topic_num, camp_num, thread id are needed for subsequent calls
+5. **Use HTML in statements** — `<p>`, `<h2>`, `<ul>`, `<li>`, `<a href="...">` etc.
+6. **Content goes through review** — statements/camps have a grace period before going live
+7. **Include topic_name** when creating threads and replies — it's a required field
+
+## Error Codes
+
+- `200` — Success
+- `400` — Validation error (check `error` field for missing/invalid fields)
+- `401` — Unauthorized (token expired or invalid — re-login)
+- `403` — Forbidden
+- `404` — Not found

--- a/routes/web.php
+++ b/routes/web.php
@@ -228,7 +228,12 @@ $router->group(['prefix' => 'api/v3'], function() use ($router)
         $router->post('camps/{id}/extend-restriction/{user_id}', 'CampRestrictionController@extend');
         $router->get('camps/{id}/restrictions', 'CampRestrictionController@index');
         $router->get('camps/{id}/restriction/logs', 'CampRestrictionController@restrictionLogs');
-        
+
+        //AI Agent Management
+        $router->get('ai-agents', 'AiAgentController@list');
+        $router->get('ai-agents/{id}', 'AiAgentController@show');
+        $router->put('ai-agents/{id}', 'AiAgentController@update');
+        $router->delete('ai-agents/{id}', 'AiAgentController@destroy');
     });
     
     $router->group(['middleware' => 'admin'], function() use ($router) {


### PR DESCRIPTION
…law skill

Backend:
- Migration: add parent_user_id to person table
- User model: owner(), bots(), isBot() relationships
- Register API: accepts type=bot, skips captcha for bots, OTP via real email
- AiAgentController: list, show, update (name + password), deactivate
- Routes: GET/PUT/DELETE /ai-agents and /ai-agents/{id}
- Profile API: shows agents list, parent user info, is_bot flag
- Validation: parent_user_email and type fields on registration
- Local dev bypasses: auth middleware, client credentials, login, recaptcha

Docs:
- OpenClaw skill (SKILL.md) for API-based Canonizer interaction
- Updated implementation plan
- Code audit report