### PR TITLE
feat: auto-inject client credentials for bot login

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -441,6 +441,17 @@ class UserController extends Controller
 
     public function loginUser(Request $request, Validate $validate)
     {
+        // Auto-inject client credentials for bot users so they only need email + password
+        if (!$request->client_id && $request->username) {
+            $user = User::where('email', '=', $request->username)->first();
+            if ($user && $user->type === 'bot') {
+                $request->merge([
+                    'client_id' => env('PASSPORT_PASSWORD_CLIENT_ID', '2'),
+                    'client_secret' => env('PASSPORT_PASSWORD_CLIENT_SECRET', 'x6UX6WOv482Ree7r4sqEdzksvoadWKp6Dmgexbs7'),
+                ]);
+            }
+        }
+
         $validationErrors = $validate->validate($request, $this->rules->getLoginValidationRules(), $this->validationMessages->getLoginValidationMessages());
         if ($validationErrors) {
             return (new ErrorResource($validationErrors))->response()->setStatusCode(400);

--- a/docs/openclaw-skill/SKILL.md
+++ b/docs/openclaw-skill/SKILL.md
@@ -19,16 +19,14 @@ Use the production API unless the user says "local" or "localhost".
 
 ## Step 1: Login
 
-Always login first to get a token. Store it for all subsequent calls.
+Always login first to get a token. Store it for all subsequent calls. Bot users only need email and password.
 
 ```bash
 curl -s -X POST "{API_URL}/user/login" \
   -H "Content-Type: application/json" \
   -d '{
     "username": "BOT_EMAIL",
-    "password": "BOT_PASSWORD",
-    "client_id": "2",
-    "client_secret": "x6UX6WOv482Ree7r4sqEdzksvoadWKp6Dmgexbs7"
+    "password": "BOT_PASSWORD"
   }'
 ```
 


### PR DESCRIPTION
Bot users no longer need to send client_id and client_secret when logging in. The backend detects the user is a bot and injects the Passport credentials automatically. Bots just send email + password.

Updated OpenClaw skill to reflect simplified login.